### PR TITLE
Use StatsBase 0.8.0's AIC, BIC and df

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ DataFrames 0.6
 Distributions 0.8
 NLopt 0.2
 Showoff
+StatsBase 0.8.0

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -10,8 +10,6 @@ export LinearMixedModel,
        MixedModel,
        VarCorr,
 
-       AIC,        # Akaike's Information Criterion
-       BIC,        # Schwatz's Bayesian Information Criterion
        bootstrap,  # Create bootstrap replications of a model
        fixef,      # extract the fixed-effects parameter estimates
        lmm,        # create a LinearMixedModel from a formula/data specification

--- a/src/pls.jl
+++ b/src/pls.jl
@@ -208,16 +208,6 @@ end
 """
 objective(m::LinearMixedModel) = logdet(m) + nobs(m)*(1.+log(2π*varest(m)))
 
-"""
-Akaike's Information Criterion
-"""
-AIC(m::LinearMixedModel) = deviance(m) + 2npar(m)
-
-"""
-Schwartz's Bayesian Information Criterion
-"""
-BIC(m::LinearMixedModel) = deviance(m) + npar(m)*log(nobs(m))
-
 ## Rename this
 Base.cholfact(m::LinearMixedModel) = UpperTriangular(m.R[end,end][1:end-1,1:end-1])
 
@@ -245,6 +235,7 @@ Note that `size(m.trms[end],2)` is `length(coef(m)) + 1`, thereby accounting
 for the scale parameter, σ, that is profiled out.
 """
 npar(m::LinearMixedModel) = size(m.trms[end],2) + length(m[:θ])
+StatsBase.df(m::LinearMixedModel) = npar(m)
 
 function Base.size(m::LinearMixedModel)
     szs = map(size,m.trms)


### PR DESCRIPTION
These functions now have generic definitions in StatsBase.
Without this, a conflict arises when running the tests, so we can't tag a new release of StatsBase.

I didn't touch `npar`, but since it's exactly the same function as `df`, we should probably keep only one of them. I find `npar` slightly misleading since people won't usually think of sigma as a parameter, but maybe that's just me.