### PR TITLE
change minimum StatsBase requirement to 0.11

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ Distributions 0.10
 GLM 0.5.2
 NLopt 0.3
 Showoff
-StatsBase 0.8.2
+StatsBase 0.11
 StatsFuns 0.2.0
 Compat 0.8.4
 DataArrays


### PR DESCRIPTION
To mirror https://github.com/JuliaLang/METADATA.jl/pull/6795/commits/11a02af019b6a709fde21823653b23527cd88776
(Hope you don't mind me using the new "allow edits by maintainers" feature to do that)

This is only technically necessary if there might be any future tags from this v0.4 branch,
but it doesn't hurt. If you're happy with things, no additional action is required from you
on the 0.5.8 tag.