### PR TITLE
Fix bug in ranef!, change isempty(offset₀) branch in setβθ!

### DIFF
--- a/src/PIRLS.jl
+++ b/src/PIRLS.jl
@@ -211,8 +211,9 @@ function setβθ!{T}(m::GeneralizedLinearMixedModel{T}, v::Vector{T})
     β, lm, offset₀, X, rr = m.β, m.LMM, m.offset₀, m.X, m.resp
     lb = length(β)
     copy!(β, view(v, 1 : lb))
+    isempty(offset₀) ? BLAS.gemv!('N', one(T), X, β, zero(T), rr.offset) :
+        BLAS.gemv!('N', one(T), X, β, one(T), copy!(rr.offset, offset₀))
     setθ!(m.LMM, copy!(m.θ, view(v, (lb + 1) : length(v))))
-    BLAS.gemv!('N', one(T), X, β, one(T), isempty(offset₀) ? fill!(rr.offset, 0) : copy!(rr.offset, offset₀))
     m
 end
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -186,10 +186,10 @@ end
     @test isapprox(objective(fm1), 237585.5534151694, atol = 1e-3)
     ftd1 = fitted(fm1);
     @test size(ftd1) == (73421,)
-    @test isapprox(ftd1[1], 3.1783062136367723, atol = 1e-5)
+    @test isapprox(ftd1[1], 3.19745, atol = 1e-4)
     resid1 = residuals(fm1);
     @test size(resid1) == (73421,)
-    @test isapprox(resid1[1], 1.8216937863632277, atol = 1e-5)
+    @test isapprox(resid1[1], 1.8025537831086234, atol = 1e-5)
 
     fm2 = fit!(lmm(y ~ 1 + service + (1 | s) + (1 | d) + (1 | dept), InstEval));
     @test size(fm2) == (73421,2,4114,3)


### PR DESCRIPTION
Fixing the bug in `ranef!` also affected `fitted` and `residuals`, which is why the tests changed.