### PR TITLE
Fix bug introduced in last commit

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -54,6 +54,7 @@ function bootstrap{T}(N, m::LinearMixedModel{T};
         fixef!(view(βs, :, i), m)
         getθ!(view(θs, :, i), m)
     end
+    refit!(m, y₀)
     objs, vars, βs, θs
 end
 

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -2,9 +2,9 @@ using Base.Test, DataFrames, MixedModels
 
 @testset "contra" begin
     contra = readtable(joinpath(dirname(@__FILE__), "data", "Contraception.csv.gz"), makefactors=true)
-    contra[:age2] = map(abs2, contra[:age])
+    contra[:age2] = abs2.(contra[:age])
     gm0 = fit!(glmm(use01 ~ 1 + age + age2 + urban + livch + (1 | urbdist), contra, Bernoulli()),
-        nAGQ=0)
+        fast=true)
     @test isapprox(LaplaceDeviance(gm0), 2361.6572; atol = 0.001)
     gm1 = fit!(glmm(use01 ~ 1 + age + age2 + urban + livch + (1 | urbdist), contra, Bernoulli()));
     @test lowerbd(gm1) == push!(fill(-Inf, 7), 0.)
@@ -32,9 +32,9 @@ end
     gm2 = fit!(glmm(prop ~ 1 + period + (1 | herd), cbpp, Binomial(), LogitLink(); wt = cbpp[:size]));
 
     @test isapprox(LaplaceDeviance(gm2), 100.095856; atol = 0.0001)
-    @test isapprox(sumabs2(gm2.u[1]), 9.72272; atol = 0.0001)
-    @test isapprox(logdet(gm2), 16.90231; atol = 0.0001)
-    @test isapprox(sum(gm2.resp.devresid), 73.47083; atol = 0.001)
+    @test isapprox(sumabs2(gm2.u[1]), 9.72306601332534; atol = 0.0001)
+    @test isapprox(logdet(gm2), 16.901079633923366; atol = 0.0001)
+    @test isapprox(sum(gm2.resp.devresid), 73.47171054657996; atol = 0.001)
     @test isapprox(loglikelihood(gm2), -92.02628; atol = 0.001)
     @test sdest(gm2) == 1
     @test varest(gm2) == 1


### PR DESCRIPTION
In the `fit!` method for `LinearMixedModel` objects, the parameters were initialized to `optsum.final`, not `optsum.initial`.   This doesn't really matter for a freshly created object because `final` is a copy of `initial`.  But it does play havoc with bootstrap replications and with simulations.