### PR TITLE
replace model frame member with fixef coefnames

### DIFF
--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -45,7 +45,7 @@ function StatsBase.coeftable(m::MixedModel)
     z = fe ./ se
     pvalue = ccdf(Chisq(1), abs2.(z))
     CoefTable(hcat(fe, se, z, pvalue), ["Estimate", "Std.Error", "z value", "P(>|z|)"],
-        coefnames(lmm(m).mf), 4)
+        lmm(m).fixefnames, 4)
 end
 
 """


### PR DESCRIPTION
The only thing the ModelFrame member of the LinearMixedModel type was used for was as an argument to `coefnames`.  I want to fix a mixed model without an actual model frame, so this PR replaces the ModelFrame member with a `Vector{String}` of fixed effect coef names which are then used directly.