### PR TITLE
Block arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: julia
 os:
   - linux
-  - osx
+#  - osx
 julia:
   - 0.6
-  - nightly
+#  - nightly
 notifications:
   email: false
 before_script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ BlockArrays
 DataArrays
 DataFrames 0.9
 Distributions 0.11
-GLM 0.6.1
+GLM 0.7
 NamedArrays
 NLopt 0.3
 Showoff

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,12 +4,12 @@ BlockArrays
 CategoricalArrays
 Compat 0.19.0
 DataArrays
-DataStructures
 DataFrames 0.9
 Distributions 0.11
 GLM 0.6.1
 NamedArrays
 NLopt 0.3
 Showoff
+StaticArrays
 StatsBase 0.11
 StatsFuns 0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,6 @@
 julia 0.6
 ArgCheck
 BlockArrays
-CategoricalArrays
-Compat 0.19.0
 DataArrays
 DataFrames 0.9
 Distributions 0.11
@@ -10,6 +8,5 @@ GLM 0.6.1
 NamedArrays
 NLopt 0.3
 Showoff
-StaticArrays
 StatsBase 0.11
 StatsFuns 0.3

--- a/benchmark/REQUIRE
+++ b/benchmark/REQUIRE
@@ -1,2 +1,3 @@
 PkgBenchmark
+DataFrames
 RData

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -81,13 +81,13 @@ fitbobyqa(rhs::Expr, dsname::Symbol) = fit!(lmm(DataFrames.Formula(:Y, rhs), dat
     end
 end
 
-#=
 @benchgroup "singlevector" ["single", "vector"] begin
     for ds in [:HR, :Oxboys, :SIMS, :sleepstudy, :Weights, :WWheat]
-        @bench string(ds) fitbobyqa($(QuoteNode(ds)))
+        for rhs in mods[ds]
+            @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        end
     end
 end
-=#
 
 @benchgroup "nested" ["multiple", "nested", "scalar"] begin
     for ds in [:Animal, :Genetics, :Pastes, :Semi2]
@@ -106,10 +106,10 @@ end
     end
 end
 
-#=
 @benchgroup "crossedvector" ["multiple", "crossed", "vector"] begin
     for ds in [:bs10, :gb12]
-        @bench string(ds) fitbobyqa($(QuoteNode(ds)))
+        for rhs in mods[ds]
+            @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        end
     end
 end
-=#

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,79 +1,91 @@
-using MixedModels, RData
+using DataFrames, RData, MixedModels
 
-const dat = convert(Dict{Symbol,Any}, load(Pkg.dir("MixedModels", "test", "dat.rda")));
+const dat = convert(Dict{Symbol,DataFrame}, load(Pkg.dir("MixedModels", "test", "dat.rda")));
 
-const mods1 = Dict{Symbol,Vector{String}}(  # models that can be benchmarked in 1 second
-    :Alfalfa => ["1+A*B+(1|G)"],
-    :Animal => ["1+(1|G)+(1|H)"],
-    :Assay => ["1+A+B*C+(1|G)+(1|H)"],
-    :AvgDailyGain => ["1+A*U+(1|G)", "1+A+U+(1|G)"],
-    :BIB => ["1+A*U+(1|G)", "1+A+U+(1|G)"],
-    :Bond => ["1+A+(1|G)"],
-    :bs10 => ["1+U+V+W+((1+U+V+W)|G)+((1+U+V+W)|H)"],
-    :cake => ["1+A*B+(1|G)"],
-    :Cultivation => ["1+A*B+(1|G)"],
-    :Demand => ["1+U+V+W+X+(1|G)+(1|H)"],
-    :Dyestuff => ["1+(1|G)"],
-    :Dyestuff2 => ["1+(1|G)"],
-    :ergoStool => ["1+A+(1|G)"],
-    :Exam => ["1+A*U+B+(1|G)", "1+A+B+U+(1|G)"],
-    :Gasoline => ["1+U+(1|G)"],
-    :gb12 => ["1+S+T+U+V+W+X+Z+((1+S+U+W)|G)+((1+S+T+V)|H)"],
-    :Genetics => ["1+A+(1|G)+(1|H)"],
-    :HR => ["1+A*U+V+(1+U|G)"],
-    :Hsb82 => ["1+A+B+C+U+(1|G)"],
-    :IncBlk => ["1+A+U+V+W+Z+(1|G)"],
-    :Mississippi => ["1+A+(1|G)"],
-    :Multilocation => ["1+A+(0+A|G)+(1|H)"],
-    :Oxboys => ["1+U+(1+U|G)"],
-    :Pastes => ["1+(1|G)+(1|H)"],
-    :PBIB => ["1+A+(1|G)"],
-    :Penicillin => ["1+(1|G)+(1|H)"],
-    :ScotsSec => ["1+A+U+V+(1|G)+(1|H)"],
-    :Semi2 => ["1+A+(1|G)+(1|H)"],
-    :Semiconductor => ["1+A*B+(1|G)"],
-    :SIMS => ["1+U+(1+U|G)"],
-    :sleepstudy => ["1+U+(1+U|G)", "1+U+(1|G)+(0+U|G)"],
-    :TeachingII => ["1+A+T+U+V+W+X+Z+(1|G)"],
-    :Weights => ["1+A*U+(1+U|G)"],
-    :WWheat => ["1+U+(1+U|G)"]
+const mods1 = Dict{Symbol,Vector{Expr}}(  # models that can be benchmarked in 1 second
+    :Alfalfa => [:(1+A*B+(1|G))],
+    :Animal => [:(1+(1|G)+(1|H))],
+    :Assay => [:(1+A+B*C+(1|G)+(1|H))],
+    :AvgDailyGain => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
+    :BIB => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
+    :Bond => [:(1+A+(1|G))],
+    :bs10 => [:(1+U+V+W+((1+U+V+W)|G)+((1+U+V+W)|H))],
+    :cake => [:(1+A*B+(1|G))],
+    :Cultivation => [:(1+A*B+(1|G))],
+    :Demand => [:(1+U+V+W+X+(1|G)+(1|H))],
+    :Dyestuff => [:(1+(1|G))],
+    :Dyestuff2 => [:(1+(1|G))],
+    :ergoStool => [:(1+A+(1|G))],
+    :Exam => [:(1+A*U+B+(1|G)), :(1+A+B+U+(1|G))],
+    :Gasoline => [:(1+U+(1|G))],
+    :gb12 => [:(1+S+T+U+V+W+X+Z+((1+S+U+W)|G)+((1+S+T+V)|H))],
+    :Genetics => [:(1+A+(1|G)+(1|H))],
+    :HR => [:(1+A*U+V+(1+U|G))],
+    :Hsb82 => [:(1+A+B+C+U+(1|G))],
+    :IncBlk => [:(1+A+U+V+W+Z+(1|G))],
+    :Mississippi => [:(1+A+(1|G))],
+    :Multilocation => [:(1+A+(0+A|G)+(1|H))],
+    :Oxboys => [:(1+U+(1+U|G))],
+    :Pastes => [:(1+(1|G)+(1|H))],
+    :PBIB => [:(1+A+(1|G))],
+    :Penicillin => [:(1+(1|G)+(1|H))],
+    :ScotsSec => [:(1+A+U+V+(1|G)+(1|H))],
+    :Semi2 => [:(1+A+(1|G)+(1|H))],
+    :Semiconductor => [:(1+A*B+(1|G))],
+    :SIMS => [:(1+U+(1+U|G))],
+    :sleepstudy => [:(1+U+(1+U|G)), :(1+U+(1|G)+(0+U|G))],
+    :TeachingII => [:(1+A+T+U+V+W+X+Z+(1|G))],
+    :Weights => [:(1+A*U+(1+U|G))],
+    :WWheat => [:(1+U+(1+U|G))]
     );
 
-const mods5 = Dict{Symbol, Vector{String}}(
-    :InstEval => ["1+A+(1|G)+(1|H)+(1|I)"]
+const mods5 = Dict{Symbol, Vector{Expr}}(
+    :InstEval => [:(1+A+(1|G)+(1|H)+(1|I))]
 );
 
-fitbobyqa(dsname::Symbol) =
-    fit!(lmm(DataFrames.Formula(:Y, parse(mods1[dsname][1])), dat[dsname]))
+fitbobyqa(rhs::Expr, dsname::Symbol) = fit!(lmm(DataFrames.Formula(:Y, rhs), dat[dsname]))
 
 @benchgroup "simplescalar" ["single", "simple", "scalar"] begin
-    for ds in [:Alfalfa, :AvgDailyGain, :BIB, :Bond, :Cultivation, :Dyestuff,
+    for ds in [:Alfalfa, :AvgDailyGain, :BIB, :Bond, :cake, :Cultivation, :Dyestuff,
         :Dyestuff2, :ergoStool, :Exam, :Gasoline, :Hsb82, :IncBlk, :Mississippi,
         :PBIB, :Semiconductor, :TeachingII]
-        @bench string(ds) fitbobyqa($(QuoteNode(ds)))
+        @show ds
+        for rhs in mods1[ds]
+            @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        end
     end
 end
 
+#=
 @benchgroup "singlevector" ["single", "vector"] begin
     for ds in [:HR, :Oxboys, :SIMS, :sleepstudy, :Weights, :WWheat]
         @bench string(ds) fitbobyqa($(QuoteNode(ds)))
     end
 end
+=#
 
 @benchgroup "nested" ["multiple", "nested", "scalar"] begin
     for ds in [:Animal, :Genetics, :Pastes, :Semi2]
-        @bench string(ds) fitbobyqa($(QuoteNode(ds)))
+        @show ds
+        for rhs in mods1[ds]
+            @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        end
     end
 end
 
 @benchgroup "crossed" ["multiple", "crossed", "scalar"] begin
-    for ds in [:Assay, :Demand, :Multilocation, :Penicillin, :ScotsSec]
-        @bench string(ds) fitbobyqa($(QuoteNode(ds)))
+    for ds in [:Assay, :Demand, :Penicillin, :ScotsSec]
+        @show ds
+        for rhs in mods1[ds]
+            @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        end
     end
 end
 
+#=
 @benchgroup "crossedvector" ["multiple", "crossed", "vector"] begin
     for ds in [:bs10, :gb12]
         @bench string(ds) fitbobyqa($(QuoteNode(ds)))
     end
 end
+=#

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,46 +2,72 @@ using DataFrames, RData, MixedModels
 
 const dat = convert(Dict{Symbol,DataFrame}, load(Pkg.dir("MixedModels", "test", "dat.rda")));
 
-const mods1 = Dict{Symbol,Vector{Expr}}(  # models that can be benchmarked in 1 second
-    :Alfalfa => [:(1+A*B+(1|G))],
+const mods = Dict{Symbol,Vector{Expr}}(
+    :Alfalfa => [:(1+A*B+(1|G)), :(1+A+B+(1|G))],
     :Animal => [:(1+(1|G)+(1|H))],
+    :Arabidopsis => [],             # glmm and rename variables
     :Assay => [:(1+A+B*C+(1|G)+(1|H))],
     :AvgDailyGain => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
     :BIB => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
     :Bond => [:(1+A+(1|G))],
-    :bs10 => [:(1+U+V+W+((1+U+V+W)|G)+((1+U+V+W)|H))],
-    :cake => [:(1+A*B+(1|G))],
-    :Cultivation => [:(1+A*B+(1|G))],
+    :Chem97 => [:(1q+(1|G)+(1|H)),:(1+U+(1|G)+(1|H))],
+    :Contraception => [],           # glmm and rename variables
+    :Cultivation => [:(1+A*B+(1|G)), :(1+A+B+(1|G)), :(1+A+(1|G))],
     :Demand => [:(1+U+V+W+X+(1|G)+(1|H))],
     :Dyestuff => [:(1+(1|G))],
     :Dyestuff2 => [:(1+(1|G))],
-    :ergoStool => [:(1+A+(1|G))],
+    :Early => [:(1+U+U&A+(1+U|G))], # variables must be renamed
     :Exam => [:(1+A*U+B+(1|G)), :(1+A+B+U+(1|G))],
     :Gasoline => [:(1+U+(1|G))],
-    :gb12 => [:(1+S+T+U+V+W+X+Z+((1+S+U+W)|G)+((1+S+T+V)|H))],
+    :Gcsemv => [:(1+A+(1|G))],      # variables must be renamed
     :Genetics => [:(1+A+(1|G)+(1|H))],
     :HR => [:(1+A*U+V+(1+U|G))],
     :Hsb82 => [:(1+A+B+C+U+(1|G))],
     :IncBlk => [:(1+A+U+V+W+Z+(1|G))],
+    :InstEval => [:(1+A+(1|G)+(1|H)+(1|I)),:(1+A*I+(1|G)+(1|H))],
+    :KKL => [],                    # variables must be renamed
+    :KWDYZ => [],                  # variables must be renamed
     :Mississippi => [:(1+A+(1|G))],
+    :Mmmec => [],                  # glmm (and offset) and variables renamed
     :Multilocation => [:(1+A+(0+A|G)+(1|H))],
     :Oxboys => [:(1+U+(1+U|G))],
-    :Pastes => [:(1+(1|G)+(1|H))],
     :PBIB => [:(1+A+(1|G))],
+    :Pastes => [:(1+(1|G)+(1|H))],
     :Penicillin => [:(1+(1|G)+(1|H))],
+    :Pixel => [:(1+U+V+(1+U|G)+(1|H))],  # variables must be renamed
+    :Poems => [:(1+U+V+W+(1|G)+(1|H)+(1|I))],
+    :Rail => [:(1+(1|G))],         # variables must be renamed
+    :SIMS => [:(1+U+(1+U|G))],
     :ScotsSec => [:(1+A+U+V+(1|G)+(1|H))],
     :Semi2 => [:(1+A+(1|G)+(1|H))],
     :Semiconductor => [:(1+A*B+(1|G))],
-    :SIMS => [:(1+U+(1+U|G))],
-    :sleepstudy => [:(1+U+(1+U|G)), :(1+U+(1|G)+(0+U|G))],
+    :Socatt => [],                 # variables must be renamed - binomial glmm?
     :TeachingII => [:(1+A+T+U+V+W+X+Z+(1|G))],
+    :VerbAgg => [:(1+A+B+C+U+(1|G)+(1|H))], # Bernoulli glmm and rename variables
     :Weights => [:(1+A*U+(1+U|G))],
-    :WWheat => [:(1+U+(1+U|G))]
+    :WWheat => [:(1+U+(1+U|G))],
+    :bdf => [],                   # rename variables and look up model
+    :bs10 => [:(1+U+V+W+((1+U+V+W)|G)+((1+U+V+W)|H))],
+    :cake => [:(1+A*B+(1|G))],
+    :cbpp => [:(1+A+(1|G))],      # Binomial glmm, create and rename variables
+    :d3 => [:(1+U+(1|G)+(1|H)+(1|I))],
+    :dialectNL => [:(1+A+T+U+V+W+X+(1|G)+(1|H)+(1|I))],
+    :egsingle => [:(1+A+U+V+(1|G)+(1|H))],
+    :epilepsy => [],              # unknown origin
+    :ergoStool => [:(1+A+(1|G))],
+    :gb12 => [:(1+S+T+U+V+W+X+Z+((1+S+U+W)|G)+((1+S+T+V)|H))],
+    :grouseticks => [],           # rename variables, glmm needs formula
+    :guimmun => [],               # rename variables, glmm needs formula
+    :guPrenat => [],              # rename variables, glmm needs formula
+    :kb07 => [:(1+S+T+U+V+W+X+Z+((1+S+T+U+V+W+X+Z)|G)+((1+S+T+U+V+W+X+Z)|H)),
+              :(1+S+T+U+V+W+X+Z+(1|G)+((0+S)|G)+((0+T)|G)+((0+U)|G)+((0+V)|G)+((0+W)|G)+
+              ((0+X)|G)+((0+Z)|G)+(1|H)+((0+S)|H)+((0+T)|H)+((0+U)|H)+((0+V)|H)+
+              ((0+W)|H)+((0+X)|H)+((0+Z)|H))],
+    :paulsim => [:(1+S+T+U+(1|H)+(1|G))],  # names of H and G should be reversed
+    :sleepstudy => [:(1+U+(1+U|G)), :(1+U+(1|G)+(0+U|G))],
+    :s3bbx => [],                 # probably drop this one
+    :star => []                   # not sure it is worthwhile working with these data
     );
-
-const mods5 = Dict{Symbol, Vector{Expr}}(
-    :InstEval => [:(1+A+(1|G)+(1|H)+(1|I))]
-);
 
 fitbobyqa(rhs::Expr, dsname::Symbol) = fit!(lmm(DataFrames.Formula(:Y, rhs), dat[dsname]))
 
@@ -49,8 +75,7 @@ fitbobyqa(rhs::Expr, dsname::Symbol) = fit!(lmm(DataFrames.Formula(:Y, rhs), dat
     for ds in [:Alfalfa, :AvgDailyGain, :BIB, :Bond, :cake, :Cultivation, :Dyestuff,
         :Dyestuff2, :ergoStool, :Exam, :Gasoline, :Hsb82, :IncBlk, :Mississippi,
         :PBIB, :Semiconductor, :TeachingII]
-        @show ds
-        for rhs in mods1[ds]
+        for rhs in mods[ds]
             @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
         end
     end
@@ -66,17 +91,16 @@ end
 
 @benchgroup "nested" ["multiple", "nested", "scalar"] begin
     for ds in [:Animal, :Genetics, :Pastes, :Semi2]
-        @show ds
-        for rhs in mods1[ds]
+        for rhs in mods[ds]
             @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
         end
     end
 end
 
 @benchgroup "crossed" ["multiple", "crossed", "scalar"] begin
-    for ds in [:Assay, :Demand, :Penicillin, :ScotsSec]
-        @show ds
-        for rhs in mods1[ds]
+    for ds in [:Assay, :Demand, :InstEval, :Penicillin, :ScotsSec, :d3, :dialectNL,
+               :egsingle, :paulsim]
+        for rhs in mods[ds]
             @bench string(ds, ':', rhs) fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
         end
     end

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -2,9 +2,8 @@ __precompile__()
 
 module MixedModels
 
-using ArgCheck, BlockArrays, CategoricalArrays, DataArrays, DataFrames
+using ArgCheck, BlockArrays, DataArrays, DataFrames
 using Distributions, GLM, NLopt, Showoff, StatsBase
-using StaticArrays: @MMatrix, MArray, MMatrix
 using StatsFuns: log2π
 using NamedArrays: NamedArray, setnames!
 using Base.LinAlg: BlasFloat, BlasReal, HermOrSym, PosDefException, checksquare, copytri!

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -4,7 +4,7 @@ module MixedModels
 
 using ArgCheck, BlockArrays, CategoricalArrays, DataArrays, DataFrames
 using Distributions, GLM, NLopt, Showoff, StatsBase
-using StaticArrays: MArray, MMatrix
+using StaticArrays: @MMatrix, MArray, MMatrix
 using StatsFuns: log2π
 using NamedArrays: NamedArray, setnames!
 using Base.LinAlg: BlasFloat, BlasReal, HermOrSym, PosDefException, checksquare, copytri!
@@ -17,14 +17,14 @@ import StatsBase: coef, coeftable, dof, deviance, fit!, fitted, loglikelihood,
 
 export
        @formula,
+       AbstractFactorReTerm,
+       AbstractReTerm,
        Bernoulli,
        Binomial,
        Block,
-       FactorReTerm,
        Gamma,
        LogitLink,
        LogLink,
-       HomoBlockDiagonal,
        InverseGaussian,
        InverseLink,
        GeneralizedLinearMixedModel,
@@ -33,7 +33,10 @@ export
        MixedModel,
        OptSummary,
        Poisson,
+       ScalarFactorReTerm,
+       UniformBlockDiagonal,
        VarCorr,
+       VectorFactorReTerm,
 
        bootstrap,
        bootstrap!,

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -2,17 +2,15 @@ __precompile__()
 
 module MixedModels
 
-using ArgCheck, BlockArrays, CategoricalArrays, Compat, DataArrays, DataFrames
+using ArgCheck, BlockArrays, CategoricalArrays, DataArrays, DataFrames
 using Distributions, GLM, NLopt, Showoff, StatsBase
+using StaticArrays: MArray, MMatrix
 using StatsFuns: log2π
 using NamedArrays: NamedArray, setnames!
 using Base.LinAlg: BlasFloat, BlasReal, HermOrSym, PosDefException, checksquare, copytri!
 
 import Base: cor, cond, convert, eltype, full, logdet, std
 import Base.LinAlg: A_mul_B!, A_mul_Bc!, Ac_mul_B!, A_ldiv_B!, Ac_ldiv_B!, A_rdiv_B!, A_rdiv_Bc!
-import DataFrames: @formula
-import Distributions: Bernoulli, Binomial, InverseGaussian, Poisson, Gamma
-import GLM: LogitLink, LogLink, InverseLink
 import NLopt: Opt
 import StatsBase: coef, coeftable, dof, deviance, fit!, fitted, loglikelihood,
     model_response, nobs, vcov
@@ -21,10 +19,12 @@ export
        @formula,
        Bernoulli,
        Binomial,
+       Block,
        FactorReTerm,
        Gamma,
        LogitLink,
        LogLink,
+       HomoBlockDiagonal,
        InverseGaussian,
        InverseLink,
        GeneralizedLinearMixedModel,
@@ -54,6 +54,7 @@ export
        loglikelihood,
        lowerbd,    # lower bounds on the covariance parameters
        model_response,
+       nblocks,
        nobs,
        objective,  # the objective function in fitting a model
        pwrss,      # penalized, weighted residual sum-of-squares

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -25,6 +25,7 @@ function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T},
     C
 end
 
+#= This is not tested.  See if it is really needed.
 function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T},
                      β::T, C::SparseMatrixCSC{T}) where T <: Number
     @argcheck B.m == C.n && A.m == C.m && A.n == B.n  DimensionMismatch
@@ -53,6 +54,7 @@ function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T},
     end
     C
 end
+=#
 
 function αβA_mul_Bc!(α::T, A::StridedVecOrMat{T}, B::SparseMatrixCSC{T}, β::T,
                      C::StridedVecOrMat{T}) where T
@@ -135,14 +137,13 @@ end
 function A_rdiv_Bc!(A::SparseMatrixCSC{T}, B::LowerTriangular{T,UniformBlockDiagonal{T}}) where {T}
     nz = nonzeros(A)
     offset = 0
-    Bdata = B.data.data
-    k, m, n = size(Bdata)
-    for d in Bdata
-        nzr = nzrange(A, offset + 1).start : nzrange(A, offset + m).stop
+    m, n, k = size(B.data.data)
+    for f in B.data.facevec
+        nzr = nzrange(A, offset + 1).start : nzrange(A, offset + n).stop
         q = div(length(nzr), m)
             ## FIXME Still allocating 1.4 GB.  Call BLAS.trsm directly
-        A_rdiv_Bc!(unsafe_wrap(Array, pointer(nz, nzr[1]), (q, m)), LowerTriangular(d))
-        offset += m
+        A_rdiv_Bc!(unsafe_wrap(Array, pointer(nz, nzr[1]), (q, m)), LowerTriangular(f))
+        offset += n
     end
     A
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -83,7 +83,7 @@ end
 αβAc_mul_B!(α::T, A::SparseMatrixCSC{T}, B::StridedVector{T}, β::T,
             C::StridedVector{T}) where T = Ac_mul_B!(α, A, B, β, C)
 
-function Ac_ldiv_B!(A::LowerTriangular{T,HomoBlockDiagonal{T,K,L}}, B::StridedVector{T}) where {T, K, L}
+function Ac_ldiv_B!(A::LowerTriangular{T,UniformBlockDiagonal{T,K,L}}, B::StridedVector{T}) where {T, K, L}
     @argcheck length(B) == size(A, 2) DimensionMismatch
     Ad = A.data.data
     k = length(Ad)
@@ -120,7 +120,7 @@ if VERSION < v"0.7.0-DEV.586"
     end
 end
 
-function A_rdiv_Bc!(A::Matrix{T}, B::LowerTriangular{T,HomoBlockDiagonal{T,K,L}}) where {T, K, L}
+function A_rdiv_Bc!(A::Matrix{T}, B::LowerTriangular{T,UniformBlockDiagonal{T,K,L}}) where {T, K, L}
     @argcheck size(A, 2) == size(B, 1) DimensionMismatch
     offset = 0
     for d in B.data.data
@@ -131,7 +131,7 @@ function A_rdiv_Bc!(A::Matrix{T}, B::LowerTriangular{T,HomoBlockDiagonal{T,K,L}}
     A
 end
 
-function A_rdiv_Bc!(A::SparseMatrixCSC{T}, B::LowerTriangular{T,HomoBlockDiagonal{T,K,L}}) where {T,K,L}
+function A_rdiv_Bc!(A::SparseMatrixCSC{T}, B::LowerTriangular{T,UniformBlockDiagonal{T,K,L}}) where {T,K,L}
     nz = nonzeros(A)
     offset = 0
     for d in B.data.data
@@ -143,10 +143,3 @@ function A_rdiv_Bc!(A::SparseMatrixCSC{T}, B::LowerTriangular{T,HomoBlockDiagona
     end
     A
 end
-
-function rowlengths(A::FactorReTerm)
-    ld = A.Λ
-    [norm(view(ld, i, 1:i)) for i in 1:size(ld, 1)]
-end
-
-rowlengths(A::MatrixTerm{T}) where {T} = T[]

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -29,10 +29,8 @@ function cholUnblocked!(A::Matrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
     A
 end
 
-function cholUnblocked!(D::Diagonal{LowerTriangular{T, Matrix{T}}},
-::Type{Val{:L}}) where T<:AbstractFloat
-    for b in D.diag
-        cholUnblocked!(b.data, Val{:L})
-    end
+function cholUnblocked!(D::LowerTriangular{T, HomoBlockDiagonal{T,K,L}},
+                        ::Type{Val{:L}}) where {T, K, L}
+    cholUnblocked!.(D.data.data, Val{:L})
     D
 end

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -13,7 +13,7 @@ function cholUnblocked!(D::Diagonal{T}, ::Type{Val{:L}}) where T<:AbstractFloat
     D
 end
 
-function cholUnblocked!(A::Matrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
+function cholUnblocked!(A::StridedMatrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
     n = checksquare(A)
     if n == 1
         A[1] < zero(T) && throw(PosDefException(1))
@@ -29,12 +29,4 @@ function cholUnblocked!(A::Matrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
     A
 end
 
-function cholUnblocked!(D::LowerTriangular{T, UniformBlockDiagonal{T}},
-                        ::Type{Val{:L}}) where {T}
-    data = D.data.data
-    l, m, n = size(data)
-    for k in 1:l
-        cholUnblocked!(view(data, k, :, :), Val{:L})
-    end
-    D
-end
+cholUnblocked!(D::UniformBlockDiagonal, ::Type{Val{:L}}) = cholUnblocked!.(D.facevec, Val{:L})

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -29,8 +29,12 @@ function cholUnblocked!(A::Matrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
     A
 end
 
-function cholUnblocked!(D::LowerTriangular{T, UniformBlockDiagonal{T,K,L}},
-                        ::Type{Val{:L}}) where {T, K, L}
-    cholUnblocked!.(D.data.data, Val{:L})
+function cholUnblocked!(D::LowerTriangular{T, UniformBlockDiagonal{T}},
+                        ::Type{Val{:L}}) where {T}
+    data = D.data.data
+    l, m, n = size(data)
+    for k in 1:l
+        cholUnblocked!(view(data, k, :, :), Val{:L})
+    end
     D
 end

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -29,7 +29,7 @@ function cholUnblocked!(A::Matrix{T}, ::Type{Val{:L}}) where T<:BlasFloat
     A
 end
 
-function cholUnblocked!(D::LowerTriangular{T, HomoBlockDiagonal{T,K,L}},
+function cholUnblocked!(D::LowerTriangular{T, UniformBlockDiagonal{T,K,L}},
                         ::Type{Val{:L}}) where {T, K, L}
     cholUnblocked!.(D.data.data, Val{:L})
     D

--- a/src/linalg/lambdaprods.jl
+++ b/src/linalg/lambdaprods.jl
@@ -15,8 +15,8 @@ the diagonal plus a copy! operation in one step.
 function Λc_mul_B! end
 function A_mul_Λ! end
 
-Λc_mul_B!(A::MatrixTerm{T}, B::AbstractArray{T}) where {T} = B
-A_mul_Λ!(A::AbstractArray{T}, B::MatrixTerm{T}) where {T} = A
+Λc_mul_B!(A::MatrixTerm, B) = B
+A_mul_Λ!(A, B::MatrixTerm) = A
 
 A_mul_Λ!(A, B::ScalarFactorReTerm) = scale!(A, B.Λ)
 Λc_mul_B!(A::ScalarFactorReTerm, B) = scale!(A.Λ, B)
@@ -75,10 +75,10 @@ end
 function Λ_mul_B!(C::StridedVecOrMat{T}, A::VectorFactorReTerm{T},
                   B::StridedVecOrMat{T}) where T
     @argcheck(size(C) == size(B), DimensionMismatch)
-    m = size(C, 1)
-    λ = LowerTriangular(A.Λ)
-    k = size(λ, 1)
-    A_mul_B!(λ, reshape(copy!(C, B), (k, size(C, 2) * div(m, k))))
+    k = vsize(A)
+    q, r = divrem(size(C, 1), k)
+    iszero(r) || throw(ArgumentError("size(C, 1) = $(size(C,1)) is not a multiple of $k = vsize(A)"))
+    A_mul_B!(LowerTriangular(A.Λ), reshape(copy!(C, B), (k, size(C, 2) * q)))
     C
 end
 

--- a/src/linalg/lambdaprods.jl
+++ b/src/linalg/lambdaprods.jl
@@ -53,7 +53,7 @@ end
 Λ_mul_B!(A::ScalarFactorReTerm{T}, B::StridedVecOrMat{T}) where T = scale!(B, A.Λ)
 
 function A_mul_Λ!(A::Matrix{T}, B::VectorFactorReTerm{T}) where T<:AbstractFloat
-    @argcheck (k = vsize(A)) > 1
+    @argcheck (k = vsize(B)) > 1
     λ = LowerTriangular(B.Λ)
     m, n = size(A)
     q, r = divrem(n, k)

--- a/src/linalg/lambdaprods.jl
+++ b/src/linalg/lambdaprods.jl
@@ -50,6 +50,8 @@ function Λ_mul_B!(A::VectorFactorReTerm{T}, B::StridedVector{T}) where T
     B
 end
 
+Λ_mul_B!(A::ScalarFactorReTerm{T}, B::StridedVecOrMat{T}) where T = scale!(B, A.Λ)
+
 function A_mul_Λ!(A::Matrix{T}, B::VectorFactorReTerm{T}) where T<:AbstractFloat
     @argcheck (k = vsize(A)) > 1
     λ = LowerTriangular(B.Λ)
@@ -67,6 +69,8 @@ function A_mul_Λ!(A::Matrix{T}, B::VectorFactorReTerm{T}) where T<:AbstractFloa
     end
     A
 end
+
+Λ_mul_B!(C::AbstractArray{T}, A::ScalarFactorReTerm{T}, B::AbstractArray{T}) where T = scale!(C, A.Λ, B)
 
 function Λ_mul_B!(C::StridedVecOrMat{T}, A::VectorFactorReTerm{T},
                   B::StridedVecOrMat{T}) where T

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -7,7 +7,7 @@ Return `log(det(tril(A)))` evaluated in place.
 """
 LD(d::Diagonal{T}) where {T<:Number} = sum(log, d.diag)
 
-function LD(d::LowerTriangular{T, HomoBlockDiagonal{T,K,L}}) where {T,K,L}
+function LD(d::LowerTriangular{T, UniformBlockDiagonal{T,K,L}}) where {T,K,L}
     s = log(one(T))
     dind = diagind(K, K)
     for dd in d.data.data, i in dind
@@ -23,6 +23,6 @@ LD(d::DenseMatrix) = sum(i -> log(d[i]), diagind(d))
 
 Return the value of `log(det(Λ'Z'ZΛ + I))` evaluated in place.
 """
-logdet(m::LinearMixedModel) = 2sum(i -> LD(m.L[Block(i, i)]), 1:nreterms(m))
+logdet(m::LinearMixedModel) = 2sum(i -> LD(m.L.data[Block(i, i)]), 1:nreterms(m))
 
 logdet(m::GeneralizedLinearMixedModel) = logdet(m.LMM)

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -7,24 +7,27 @@ Return `log(det(tril(A)))` evaluated in place.
 """
 LD(d::Diagonal{T}) where {T<:Number} = sum(log, d.diag)
 
-function LD(d::LowerTriangular{T, UniformBlockDiagonal{T}}) where {T}
-    s = log(one(T))
-#= FIXME This is broken
-    dind = diagind(K, K)
-    for dd in d.data.data, i in dind
-        s += log(dd[i])
-    end
-=#
-    s
+function LD(d::UniformBlockDiagonal{T}) where T
+    m, n, k = size(d.data)
+    dind = diagind(m, n)
+    sum(log, f[i] for f in d.facevec, i in dind)
 end
 
-LD(d::DenseMatrix) = sum(i -> log(d[i]), diagind(d))
+LD(d::DenseMatrix{T}) where {T} = sum(i -> log(d[i]), diagind(d))
 
 """
     logdet(m::LinearMixedModel)
 
 Return the value of `log(det(Λ'Z'ZΛ + I))` evaluated in place.
 """
-logdet(m::LinearMixedModel{T}) where {T} = 2sum(i -> T(LD(m.L.data[Block(i, i)])), 1:nreterms(m))
+function logdet(m::LinearMixedModel{T}) where {T}
+    s = zero(T)
+    for (i, trm) in enumerate(m.trms)
+        if isa(trm, AbstractFactorReTerm)
+            s += T(LD(m.L.data[Block(i, i)]))
+        end
+    end
+    2s
+end
 
 logdet(m::GeneralizedLinearMixedModel) = logdet(m.LMM)

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -13,7 +13,7 @@ function LD(d::UniformBlockDiagonal{T}) where T
     sum(log, f[i] for f in d.facevec, i in dind)
 end
 
-LD(d::DenseMatrix{T}) where {T} = sum(i -> log(d[i]), diagind(d))
+LD(d::DenseMatrix{T}) where {T} = sum(log, d[i] for i in diagind(d))
 
 """
     logdet(m::LinearMixedModel)

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -23,6 +23,6 @@ LD(d::DenseMatrix) = sum(i -> log(d[i]), diagind(d))
 
 Return the value of `log(det(Λ'Z'ZΛ + I))` evaluated in place.
 """
-logdet(m::LinearMixedModel) = 2sum(i -> LD(m.L.data[Block(i, i)]), 1:nreterms(m))
+logdet(m::LinearMixedModel{T}) where {T} = 2sum(i -> T(LD(m.L.data[Block(i, i)])), 1:nreterms(m))
 
 logdet(m::GeneralizedLinearMixedModel) = logdet(m.LMM)

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -7,12 +7,14 @@ Return `log(det(tril(A)))` evaluated in place.
 """
 LD(d::Diagonal{T}) where {T<:Number} = sum(log, d.diag)
 
-function LD(d::LowerTriangular{T, UniformBlockDiagonal{T,K,L}}) where {T,K,L}
+function LD(d::LowerTriangular{T, UniformBlockDiagonal{T}}) where {T}
     s = log(one(T))
+#= FIXME This is broken
     dind = diagind(K, K)
     for dd in d.data.data, i in dind
         s += log(dd[i])
     end
+=#
     s
 end
 

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -44,8 +44,8 @@ function rankUpdate!(α::T, A::SparseMatrixCSC{T}, β::T, C::HermOrSym{T,S}) whe
     C
 end
 
-rankUpdate!(α::T, A::SparseMatrixCSC{T},
-C::HermOrSym{T,S}) where {T<:AbstractFloat,S<:StridedMatrix} = rankUpdate!(α, A, one(T), C)
+rankUpdate!(α::T, A::SparseMatrixCSC{T}, C::HermOrSym{T}) where {T} =
+    rankUpdate!(α, A, one(T), C)
 
 function rankUpdate!(α::T, A::SparseMatrixCSC{T}, C::Diagonal{T}) where T <: Number
     m, n = size(A)
@@ -63,7 +63,7 @@ function rankUpdate!(α::T, A::SparseMatrixCSC{T}, C::Diagonal{T}) where T <: Nu
 end
 
 function rankUpdate!(α::T, A::SparseMatrixCSC{T},
-                     C::LowerTriangular{T,HomoBlockDiagonal{T,K,L}}) where {T<:Number,K,L}
+                     C::LowerTriangular{T,UniformBlockDiagonal{T,K,L}}) where {T<:Number,K,L}
     m, n = size(A)
     @argcheck size(C, 1) == m DimensionMismatch
     @assert K > 1

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -63,14 +63,14 @@ function rankUpdate!(α::T, A::SparseMatrixCSC{T}, C::Diagonal{T}) where T <: Nu
 end
 
 function rankUpdate!(α::T, A::SparseMatrixCSC{T},
-                     C::LowerTriangular{T,UniformBlockDiagonal{T,K,L}}) where {T<:Number,K,L}
+                     C::LowerTriangular{T,UniformBlockDiagonal{T}}) where {T<:Number}
     m, n = size(A)
     @argcheck size(C, 1) == m DimensionMismatch
-    @assert K > 1
     aat = α * (A * A')
     nz = nonzeros(aat)
     rv = rowvals(aat)
     offset = 0
+#=   FIXME: This is broken
     for d in C.data.data
         for j in 1:K
             for i in nzrange(aat, offset + j)
@@ -83,5 +83,6 @@ function rankUpdate!(α::T, A::SparseMatrixCSC{T},
         end
         offset += K
     end
+=#
     C
 end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -20,7 +20,7 @@ rankUpdate!(α::T, A::StridedMatrix{T}, C::HermOrSym{T,S}) where {T<:Real,S<:Str
 rankUpdate!(A::StridedMatrix{T}, C::HermOrSym{T,S}) where {T<:Real,S<:StridedMatrix} =
     rankUpdate!(one(T), A, one(T), C)
 
-function rankUpdate!(α::T, A::SparseMatrixCSC{T}, β::T, C::HermOrSym{T,S}) where {T<:AbstractFloat,S<:StridedMatrix}
+function rankUpdate!(α::T, A::SparseMatrixCSC{T,I}, β::T, C::HermOrSym{T,S}) where {T,I,S}
     m, n = size(A)
     @argcheck m == size(C, 2) && C.uplo == 'L' DimensionMismatch
     Cd = C.data

--- a/src/linalg/scaleInflate.jl
+++ b/src/linalg/scaleInflate.jl
@@ -6,38 +6,41 @@ is a [`MatrixTerm`]{@ref}, in which case this becomes `copy!(L, A)`.
 """
 function scaleInflate! end
 
-function scaleInflate!(Ljj::Matrix{T}, Ajj::Matrix{T}, Λj::MatrixTerm{T}) where T
+function scaleInflate!(Ljj::LowerTriangular{T,Matrix{T}}, Ajj::Matrix{T},
+                       Λj::MatrixTerm{T}) where T
     @argcheck(size(Ljj) == size(Ajj), DimensionMismatch)
-    copy!(Ljj, Ajj)
+    copy!(Ljj.data, Ajj)
 end
 
 function scaleInflate!(Ljj::Diagonal{T}, Ajj::Diagonal{T},
-                     Λj::FactorReTerm{T}) where T<:AbstractFloat
+                     Λj::ScalarFactorReTerm{T}) where T<:AbstractFloat
     @argcheck(length(Λj.Λ) == 1, DimensionMismatch)
     broadcast!((x,k) -> k * x + one(T), Ljj.diag, Ajj.diag, abs2(Λj.Λ[1]))
     Ljj
 end
 
-function scaleInflate!(Ljj::Matrix{T}, Ajj::Diagonal{T},
-                       Λj::FactorReTerm{T}) where T<:AbstractFloat
+function scaleInflate!(Ljj::LowerTriangular{T,Matrix{T}}, Ajj::Diagonal{T},
+                       Λj::ScalarFactorReTerm{T}) where T
+    Ldat = Ljj.data
     Ad = Ajj.diag
-    @argcheck(length(Ad) == checksquare(Ljj) && length(Λj.Λ) == 1, DimensionMismatch)
-    lambsq = abs2(Λj.Λ[1])
-    fill!(Ljj, zero(T))
-    for (j, jj) in zip(eachindex(Ad), diagind(Ljj))
-        Ljj[jj] = lambsq * Ad[j] + one(T)
+    @argcheck(length(Ad) == size(Ldat, 1), DimensionMismatch)
+    lambsq = abs2(Λj.Λ)
+    fill!(Ldat, zero(T))
+    for (j, jj) in zip(eachindex(Ad), diagind(Ldat))
+        Ldat[jj] = lambsq * Ad[j] + one(T)
     end
     Ljj
 end
 
-function scaleInflate!(Ljj::LowerTriangular{T,HomoBlockDiagonal{T,K,L}},
-                       Ajj::HomoBlockDiagonal{T,K,L}, Λj::FactorReTerm{T}) where {T,K,L}
+function scaleInflate!(Ljj::LowerTriangular{T,UniformBlockDiagonal{T,K,L}},
+                       Ajj::UniformBlockDiagonal{T,K,L},
+                       Λj::VectorFactorReTerm{T}) where {T,K,L}
     @argcheck size(Ljj) == size(Ajj) DimensionMismatch
     λ = LowerTriangular(Λj.Λ)
     Ldiag = Ljj.data.data
     Adiag = Ajj.data
     for i in eachindex(Ldiag)
-        Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Ldiag[i].data, Adiag[i]), λ))
+        Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Ldiag[i], Adiag[i]), λ))
         for k in diagind(Ldi)
             Ldi[k] += one(T)
         end
@@ -45,8 +48,8 @@ function scaleInflate!(Ljj::LowerTriangular{T,HomoBlockDiagonal{T,K,L}},
     Ljj
 end
 
-function scaleInflate!(Ljj::Matrix{T}, Ajj::HomoBlockDiagonal{T},
-                       Λj::FactorReTerm{T}) where T<:AbstractFloat
+function scaleInflate!(Ljj::Matrix{T}, Ajj::UniformBlockDiagonal{T},
+                       Λj::VectorFactorReTerm{T}) where T<:AbstractFloat
     @argcheck size(Ljj) == size(Ajj) DimensionMismatch
     Adiag = Ajj.data
     λ = LowerTriangular(Λj.Λ)

--- a/src/linalg/scaleInflate.jl
+++ b/src/linalg/scaleInflate.jl
@@ -32,19 +32,21 @@ function scaleInflate!(Ljj::LowerTriangular{T,Matrix{T}}, Ajj::Diagonal{T},
     Ljj
 end
 
-function scaleInflate!(Ljj::LowerTriangular{T,UniformBlockDiagonal{T,K,L}},
-                       Ajj::UniformBlockDiagonal{T,K,L},
-                       Λj::VectorFactorReTerm{T}) where {T,K,L}
+function scaleInflate!(Ljj::LowerTriangular{T,UniformBlockDiagonal{T}},
+                       Ajj::UniformBlockDiagonal{T},
+                       Λj::VectorFactorReTerm{T}) where {T}
     @argcheck size(Ljj) == size(Ajj) DimensionMismatch
     λ = LowerTriangular(Λj.Λ)
     Ldiag = Ljj.data.data
     Adiag = Ajj.data
+#= FIXME: This is broken
     for i in eachindex(Ldiag)
         Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Ldiag[i], Adiag[i]), λ))
         for k in diagind(Ldi)
             Ldi[k] += one(T)
         end
     end
+=#
     Ljj
 end
 

--- a/src/linalg/scaleInflate.jl
+++ b/src/linalg/scaleInflate.jl
@@ -37,12 +37,11 @@ function scaleInflate!(Ljj::LowerTriangular{T,UniformBlockDiagonal{T}},
                        Λj::VectorFactorReTerm{T}) where {T}
     @argcheck size(Ljj) == size(Ajj) DimensionMismatch
     λ = LowerTriangular(Λj.Λ)
-    Lfv = Ljj.data.facevec
-    Afv = Ajj.facevec
-    for i in eachindex(Lfv)
-        Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Lfv[i], Afv[i]), λ))
-        for k in diagind(Ldi)
-            Ldi[k] += one(T)
+    k = vsize(Λj)
+    for (Lf, Af) in zip(Ljj.data.facevec, Ajj.facevec)
+        Ac_mul_B!(λ, A_mul_B!(copy!(Lf, Af), λ))
+        for j in 1:k
+            Lf[j, j] += one(T)
         end
     end
     Ljj

--- a/src/linalg/scaleInflate.jl
+++ b/src/linalg/scaleInflate.jl
@@ -37,16 +37,14 @@ function scaleInflate!(Ljj::LowerTriangular{T,UniformBlockDiagonal{T}},
                        Λj::VectorFactorReTerm{T}) where {T}
     @argcheck size(Ljj) == size(Ajj) DimensionMismatch
     λ = LowerTriangular(Λj.Λ)
-    Ldiag = Ljj.data.data
-    Adiag = Ajj.data
-#= FIXME: This is broken
-    for i in eachindex(Ldiag)
-        Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Ldiag[i], Adiag[i]), λ))
+    Lfv = Ljj.data.facevec
+    Afv = Ajj.facevec
+    for i in eachindex(Lfv)
+        Ldi = Ac_mul_B!(λ, A_mul_B!(copy!(Lfv[i], Afv[i]), λ))
         for k in diagind(Ldi)
             Ldi[k] += one(T)
         end
     end
-=#
     Ljj
 end
 

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -6,11 +6,7 @@
 Return the lower Cholesky factor for the fixed-effects parameters, as an `LowerTriangular`
 `p × p` matrix.
 """
-function feL(m::MixedModel)
-    L = lmm(m).L
-    kp1 = nblocks(L, 1) - 1
-    LowerTriangular(L[Block(kp1, kp1)])
-end
+feL(m::MixedModel) = LowerTriangular(lmm(m).L.data.blocks[end - 1, end - 1])
 
 """
     lmm(m::MixedModel)
@@ -66,7 +62,7 @@ function describeblocks(io::IO, m::MixedModel)
     L = lm.L
     for i in 1 : nblocks(A, 2), j in 1 : i
         println(io, i, ",", j, ": ", typeof(A[Block(i, j)]), " ",
-                blocksize(A, i, j), " ", typeof(L[Block(i, j)]))
+                blocksize(A, i, j), " ", typeof(L.data[Block(i, j)]))
     end
 end
 describeblocks(m::MixedModel) = describeblocks(Base.STDOUT, m)
@@ -102,10 +98,10 @@ Return the number of levels in the random-effects terms' grouping factors.
 """
 grplevels(m::MixedModel) = nlevs.(reterms(m))
 
-nreterms(m::MixedModel) = sum(t -> isa(t, FactorReTerm), lmm(m).trms)
+nreterms(m::MixedModel) = sum(t -> isa(t, AbstractFactorReTerm), lmm(m).trms)
 
-reterms(m::MixedModel) =
-    convert(Vector{FactorReTerm}, filter(t -> isa(t, FactorReTerm), lmm(m).trms))
+reterms(m::MixedModel) = convert(Vector{AbstractFactorReTerm},
+                                 filter(t -> isa(t, AbstractFactorReTerm), lmm(m).trms))
 
 """
     ranef!{T}(v::Vector{Matrix{T}}, m::MixedModel{T}, β, uscale::Bool)
@@ -116,18 +112,18 @@ If `uscale` is `true` the random effects are on the spherical (i.e. `u`) scale, 
 on the original scale
 """
 function ranef!(v::Vector, m::LinearMixedModel{T}, β::AbstractArray{T}, uscale::Bool) where T
-    L = m.L
+    Ldat = m.L.data
     @argcheck((k = length(v)) == nreterms(m), DimensionMismatch)
     for j in 1:k
-        αβAc_mul_B!(-one(T), L[Block(k + 1, j)], β, one(T), vec(copy!(v[j],
-                    L[Block(nblocks(L, 2), j)])))
+        αβAc_mul_B!(-one(T), Ldat[Block(k + 1, j)], β, one(T), vec(copy!(v[j],
+                    Ldat[Block(nblocks(Ldat, 2), j)])))
     end
     for i in k: -1 :1
-        Lii = L[Block(i, i)]
+        Lii = Ldat[Block(i, i)]
         vi = vec(v[i])
         Ac_ldiv_B!(isa(Lii, Diagonal) ? Lii : LowerTriangular(Lii), vi)
         for j in 1:(i - 1)
-            αβAc_mul_B!(-one(T), L[Block(i, j)], vi, one(T), vec(v[j]))
+            αβAc_mul_B!(-one(T), Ldat[Block(i, j)], vi, one(T), vec(v[j]))
         end
     end
     if !uscale
@@ -139,11 +135,7 @@ function ranef!(v::Vector, m::LinearMixedModel{T}, β::AbstractArray{T}, uscale:
     v
 end
 
-function ranef!(v::Vector, m::LinearMixedModel, uscale::Bool)
-    L = m.L
-    nblk = nblocks(L, 2)
-    ranef!(v, m, Ac_ldiv_B(feL(m), vec(copy(L[Block(nblk, nblk - 1)]))), uscale)
-end
+ranef!(v::Vector, m::LinearMixedModel, uscale::Bool) = ranef!(v, m, fixef(m), uscale)
 
 """
     ranef{T}(m::MixedModel{T}, uscale=false)
@@ -196,7 +188,7 @@ diagonal blocks from the conditional variance-covariance matrix,
 function condVar(m::MixedModel)
     lm = lmm(m)
     λ = lm.trms[1]
-    L11 = lm.L[Block(1, 1)]
+    L11 = lm.L.data[Block(1, 1)]
     if nreterms(lm) ≠ 1 || !isa(L11, Diagonal{eltype(λ)})
         throw(ArgumentError("code for vector-valued r.e. or more than one term not yet written"))
     end

--- a/src/modelterms.jl
+++ b/src/modelterms.jl
@@ -49,6 +49,26 @@ A_mul_B!(R::StridedVecOrMat{T}, A::MatrixTerm{T}, B::StridedVecOrMat{T}) where {
 abstract type AbstractFactorReTerm{T} <: AbstractTerm{T} end
 
 """
+    isnested(A, B)
+
+Is factor `A` nested in factor `B`?  That is, does each value of `A` occur with just
+one value of B?
+"""
+function isnested(A::PooledDataVector{V,R}, B::PooledDataVector{W,S}) where {V,R,W,S}
+    @argcheck length(A) == length(B) DimensionMismatch
+    bins = zeros(S, length(A.pool))
+    @inbounds for (a, b) in zip(A.refs, B.refs)
+        bba = bins[a]
+        if iszero(bba)
+            bins[a] = b
+        elseif bba ≠ b
+            return false
+        end
+    end
+    true
+end
+
+"""
     ScalarFactorReTerm
 
 Scalar random-effects term from a grouping factor
@@ -488,6 +508,7 @@ function Ac_mul_B!(C::Matrix{T}, A::ScalarFactorReTerm{T}, B::ScalarFactorReTerm
     C
 end
 
+#=  Methods not tested.  Comment out to see if they are really needed.
 function Ac_mul_B!(C::Matrix{T}, A::VectorFactorReTerm{T}, B::VectorFactorReTerm{T}) where T
     m, n = size(B)
     @argcheck size(C, 1) == size(A, 2) && n == size(C, 2) && size(A, 1) == m DimensionMismatch
@@ -554,3 +575,4 @@ function Ac_mul_B!(C::SparseMatrixCSC{T}, A::VectorFactorReTerm{T}, B::VectorFac
     end
     C
 end
+=#

--- a/src/modelterms.jl
+++ b/src/modelterms.jl
@@ -465,24 +465,10 @@ function Ac_mul_B!(C::UniformBlockDiagonal{T,K,L}, A::VectorFactorReTerm{T},
     C
 end
 
-function vprod(a::Ones,b::Ones)
-    @argcheck((n = length(a)) == length(b), DimensionMismatch)
-    ones(promote_type(eltype(a), eltype(b)), n)
-end
-
-function vprod(a::Ones, b::AbstractVector)
-    @argcheck((n = length(a)) == length(b), DimensionMismatch)
-    copy!(Vector(promote_type(eltype(a), eltype(b)), n), b)
-end
-
-vprod(a::AbstractVector, b::Ones) = vprod(b, a)
-
-vprod(a::AbstractVector, b::AbstractVector) = a .* b
-
 function Base.Ac_mul_B(A::ScalarFactorReTerm{T}, B::ScalarFactorReTerm{T}) where T
     A == B && return Ac_mul_B!(Diagonal(Vector{T}(nlevs(A))), A, B)
     sparse(convert(Vector{Int32}, A.f.refs), convert(Vector{Int32}, B.f.refs),
-           vprod(A.wtz, B.wtz))
+           A.wtz .* B.wtz)
 end
 
 function Base.Ac_mul_B(A::VectorFactorReTerm{T}, B::VectorFactorReTerm{T}) where T

--- a/src/modelterms.jl
+++ b/src/modelterms.jl
@@ -3,7 +3,7 @@
 
 Term with an explicit, constant matrix representation
 
-#Members
+# Members
 * `x`: matrix
 * `wtx`: weighted matrix
 * `cnames`: vector of column names
@@ -348,11 +348,11 @@ function Ac_mul_B!(C::Diagonal{T}, A::FactorReTerm{T}, B::FactorReTerm{T}) where
     C
 end
 
-function Ac_mul_B!(C::Diagonal{Matrix{T}}, A::FactorReTerm{T}, B::FactorReTerm{T}) where T
+function Ac_mul_B!(C::HomoBlockDiagonal{T,K,L}, A::FactorReTerm{T}, B::FactorReTerm{T}) where {T,K,L}
     Az = A.wtz
     l, n = size(Az)
-    @argcheck A === B && all(d -> size(d) == (l, l), C.diag)
-    d = C.diag
+    @argcheck A === B && l == K
+    d = C.data
     fill!.(d, zero(T))
     refs = A.f.refs
     @inbounds for i in eachindex(refs)
@@ -373,7 +373,8 @@ function Base.Ac_mul_B(A::FactorReTerm{T}, B::FactorReTerm{T}) where T
         if l == 1
             return Ac_mul_B!(Diagonal(Vector{T}(nlevs(A))), A, A)
         else
-            return Ac_mul_B!(Diagonal([zeros(T, (l,l)) for _ in 1:nlevs(A)]), A, A)
+            return Ac_mul_B!(HomoBlockDiagonal([MMatrix{l,l}(zeros(T,abs2(l)))
+                                               for _ in 1:nlevs(A)]), A, A)
         end
     end
     Az = A.wtz

--- a/src/pls.jl
+++ b/src/pls.jl
@@ -103,7 +103,7 @@ function lmm(f::Formula, fr::AbstractDataFrame;
     isempty(tdict) && throw(ArgumentError("No random-effects terms found in $f"))
     trms = AbstractTerm{T}[]
     for (grp, lhs) in tdict
-        gr = asfactor(getindex(mf.df, grp))
+        gr = compact(pool(getindex(mf.df, grp)))
         if (length(lhs) == 1 && lhs[1] == 1)
             push!(trms, ScalarFactorReTerm(gr, grp))
         else

--- a/src/pls.jl
+++ b/src/pls.jl
@@ -296,7 +296,17 @@ sdest(m::LinearMixedModel) = sqrtpwrss(m) / √nobs(m)
 Install `v` as the θ parameters in `m`.
 """
 function setθ!(m::LinearMixedModel, v)
-    setθ!(m.trms, v)
+    offset = 0
+    for trm in m.trms
+        if isa(trm, ScalarFactorReTerm)
+            offset += 1
+            setθ!(trm, v[offset])
+        else
+            k = nθ(trm)
+            iszero(k) || setθ!(trm, view(v, (1:k) + offset))
+            offset += k
+        end
+    end
     m
 end
 

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -123,7 +123,12 @@ function stddevcor!(σ::Vector{T}, ρ::Matrix{T}, scr::Matrix{T}, L::LinAlg.Chol
     end
     σ, ρ
 end
-function stddevcor!(σ::Vector{T}, ρ::Matrix{T}, scr::Matrix{T}, L::FactorReTerm{T}) where T
+function stddevcor!(σ::Vector, ρ::Matrix, scr::Matrix, L::ScalarFactorReTerm)
+    σ[1] = L.Λ
+    ρ[1] = 1
+end
+function stddevcor!(σ::Vector{T}, ρ::Matrix{T}, scr::Matrix{T},
+    L::VectorFactorReTerm{T}) where T
     stddevcor!(σ, ρ, scr, LinAlg.Cholesky(LowerTriangular(L.Λ)))
 end
 function stddevcor(L::LinAlg.Cholesky{T}) where T
@@ -131,7 +136,8 @@ function stddevcor(L::LinAlg.Cholesky{T}) where T
     stddevcor!(Vector{T}(k), Matrix{T}((k, k)), Matrix{T}((k, k)), L)
 end
 stddevcor(L::LowerTriangular) = stddevcor(LinAlg.Cholesky(L))
-stddevcor(L::FactorReTerm) = stddevcor(LowerTriangular(L.Λ))
+stddevcor(L::VectorFactorReTerm) = stddevcor(LowerTriangular(L.Λ))
+stddevcor(L::ScalarFactorReTerm{T}) where T = [L.Λ], ones(T, 1, 1)
 
 if VERSION < v"0.7.0-DEV.393"
     Base.LinAlg.Cholesky(L::LowerTriangular) = LinAlg.Cholesky(L, 'L')
@@ -193,13 +199,26 @@ function resetθ!(m::LinearMixedModel)
 end
 
 """
-    unscaledre!(y::AbstractVector{T}, M::ReMat{T}, L) where T
+    unscaledre!(y::AbstractVector{T}, M::AbstractFactorReTerm{T}, b) where T
+    unscaledre!(rng::AbstractRNG, y::AbstractVector{T}, M::AbstractFactorReTerm{T}) where T
 
-Add unscaled random effects defined by `M` and `L * randn(1, length(M.f.pool))` to `y`.
+Add unscaled random effects defined by `M` and `b` to `y`.  When `rng` is present the `b`
+vector is generated as `randn(rng, size(M, 2))`
 """
 function unscaledre! end
 
-function unscaledre!(y::AbstractVector{T}, A::FactorReTerm{T}, b::DenseMatrix{T}) where T
+function unscaledre!(y::AbstractVector, A::ScalarFactorReTerm, b::AbstractVecOrMat)
+    m, n = size(A)
+    @argcheck(length(y) == m && length(b) == n, DimensionMismatch)
+    z = A.z
+    r = A.f.refs
+    for i in eachindex(r)
+        y[i] += b[r[i]] * z[i]
+    end
+    y
+end
+
+function unscaledre!(y::AbstractVector, A::VectorFactorReTerm, b::DenseMatrix)
     Z = A.z
     k, n = size(Z)
     l = nlevs(A)
@@ -214,11 +233,11 @@ function unscaledre!(y::AbstractVector{T}, A::FactorReTerm{T}, b::DenseMatrix{T}
     y
 end
 
-function unscaledre!(rng::AbstractRNG, y::AbstractVector{T}, A::FactorReTerm{T}) where T
+function unscaledre!(rng::AbstractRNG, y::AbstractVector, A::AbstractFactorReTerm)
     unscaledre!(y, A, A_mul_B!(LowerTriangular(A.Λ), randn(rng, vsize(A), nlevs(A))))
 end
 
-unscaledre!(y::AbstractVector, A::FactorReTerm) = unscaledre!(Base.GLOBAL_RNG, y, A)
+unscaledre!(y::AbstractVector, A::AbstractFactorReTerm) = unscaledre!(Base.GLOBAL_RNG, y, A)
 
 """
     simulate!(m::LinearMixedModel; β=fixef(m), σ=sdest(m), θ=getθ(m))
@@ -241,5 +260,3 @@ end
 
 simulate!(m::LinearMixedModel{T}; β=coef(m), σ=sdest(m), θ=T[]) where {T} =
     simulate!(Base.GLOBAL_RNG, m, β=β, σ=σ, θ=θ)
-
-StatsBase.model_response(m::LinearMixedModel) = vec(m.trms[end].x)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -218,7 +218,8 @@ function unscaledre!(y::AbstractVector, A::ScalarFactorReTerm, b::AbstractVecOrM
     y
 end
 
-function unscaledre!(y::AbstractVector, A::VectorFactorReTerm, b::DenseMatrix)
+function unscaledre!(y::AbstractVector{T}, A::VectorFactorReTerm{T,V,R},
+                     b::DenseMatrix) where {T,V,R}
     Z = A.z
     k, n = size(Z)
     l = nlevs(A)
@@ -233,8 +234,14 @@ function unscaledre!(y::AbstractVector, A::VectorFactorReTerm, b::DenseMatrix)
     y
 end
 
-function unscaledre!(rng::AbstractRNG, y::AbstractVector, A::AbstractFactorReTerm)
+function unscaledre!(rng::AbstractRNG, y::AbstractVector{T},
+                     A::VectorFactorReTerm{T}) where T
     unscaledre!(y, A, A_mul_B!(LowerTriangular(A.Λ), randn(rng, vsize(A), nlevs(A))))
+end
+
+function unscaledre!(rng::AbstractRNG, y::AbstractVector{T},
+                     A::ScalarFactorReTerm{T}) where T
+    unscaledre!(y, A, scale!(A.Λ, randn(rng, vsize(A), nlevs(A))))
 end
 
 unscaledre!(y::AbstractVector, A::AbstractFactorReTerm) = unscaledre!(Base.GLOBAL_RNG, y, A)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -97,10 +97,7 @@ end
 
 function stddevcor!(σ::Vector{T}, ρ::Matrix{T}, scr::Matrix{T}, L::LinAlg.Cholesky{T}) where T
     @argcheck length(σ) == (k = size(L, 2)) && size(ρ) == (k, k) && size(scr) == (k, k) DimensionMismatch
-    if k == 1
-        copy!(σ, L.factors)
-        ρ[1, 1] = one(T)
-    elseif L.uplo == 'L'
+    if L.uplo == 'L'
         copy!(scr, L.factors)
         for i in 1 : k
             σ[i] = σi = norm(view(scr, i, 1 : i))

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -158,8 +158,9 @@ function reevaluateAend!(m::LinearMixedModel)
     A = m.A
     trms = m.trms
     trmn = reweight!(trms[end], m.sqrtwts)
+    nblk = nblocks(A, 2)
     for i in eachindex(trms)
-        Ac_mul_B!(A[end, i], trmn, trms[i])
+        Ac_mul_B!(A[Block(nblk, i)], trmn, trms[i])
     end
     m
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,20 +1,4 @@
 """
-    HeteroBlkdMatrix
-
-A matrix composed of heterogenous blocks.  Blocks can be sparse, dense or
-diagonal.
-"""
-# FIXME: Change this to use the AbstractBlockArray interface
-
-struct HeteroBlkdMatrix <: AbstractMatrix{AbstractMatrix}
-    blocks::Matrix{AbstractMatrix}
-end
-Base.size(A::HeteroBlkdMatrix) = size(A.blocks)
-Base.getindex(A::HeteroBlkdMatrix, i::Int) = A.blocks[i]
-Base.setindex!(A::HeteroBlkdMatrix, X, i::Integer) = setindex!(A.blocks, X, i)
-Base.IndexStyle(A::HeteroBlkdMatrix) = IndexLinear()
-
-"""
     OptSummary
 
 Summary of an `NLopt` optimization
@@ -117,8 +101,8 @@ struct LinearMixedModel{T <: AbstractFloat} <: MixedModel{T}
     formula::Formula
     trms::Vector{AbstractTerm{T}}
     sqrtwts::Vector{T}
-    A::Hermitian             # cross-product blocks
-    L::LowerTriangular
+    A::BlockMatrix{T}            # cross-product blocks
+    L::BlockMatrix{T}
     optsum::OptSummary{T}
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,6 +50,20 @@ function Base.getindex(A::UniformBlockDiagonal{T}, i::Int, j::Int) where {T}
     end
 end
 
+function Base.full(A::UniformBlockDiagonal{T}) where T
+    res = zeros(T, size(A))
+    Ad = A.data
+    m, n, l = size(Ad)
+    offseti = 0
+    offsetj = 0
+    for k = 1:l
+        for j = 1:n, i = 1:m
+            res[offseti + i, offsetj + j] = Ad[i, j, k]
+        end
+    end
+    res
+end
+
 """
     OptSummary
 
@@ -228,8 +242,8 @@ end
 
 function Base.show(io::IO, vc::VarCorr)
     # FIXME: Do this one term at a time
-    fnms = vc.fnms
-    stdm = vc.σ
+    fnms = copy(vc.fnms)
+    stdm = copy(vc.σ)
     cor = vc.ρ
     cnms = reduce(append!, String[], vc.cnms)
     if isfinite(vc.s)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,18 +1,18 @@
 """
-    HomoBlockDiagonal{T,B}
+    UniformBlockDiagonal{T,B}
 
 Homogeneous block diagonal matrices.  `k` diagonal blocks each of size `m×m`
 """
-struct HomoBlockDiagonal{T,B,L} <: AbstractMatrix{T}
+struct UniformBlockDiagonal{T,B,L} <: AbstractMatrix{T}
     data::Vector{MArray{Tuple{B,B},T,B,L}}
 end
 
-function Base.size(A::HomoBlockDiagonal{T,B}) where {T, B}
+function Base.size(A::UniformBlockDiagonal{T,B}) where {T, B}
     m = length(A.data) * B
     m, m
 end
 
-function Base.size(A::HomoBlockDiagonal{T,B}, i::Int) where {T, B}
+function Base.size(A::UniformBlockDiagonal{T,B}, i::Int) where {T, B}
     if i ≤ 0
         throw(ArgumentError("i = $i should be positive"))
     elseif 0 < i ≤ 2
@@ -22,7 +22,7 @@ function Base.size(A::HomoBlockDiagonal{T,B}, i::Int) where {T, B}
     end
 end
 
-function Base.getindex(A::HomoBlockDiagonal{T,B}, i::Int, j::Int) where {T, B}
+function Base.getindex(A::UniformBlockDiagonal{T,B}, i::Int, j::Int) where {T, B}
     m = length(A.data) * B
     (0 < i ≤ m && 0 < j ≤ m) ||
         throw(IndexError("attempt to access $m \times $m array at index [$i, $j]"))
@@ -35,6 +35,27 @@ function Base.getindex(A::HomoBlockDiagonal{T,B}, i::Int, j::Int) where {T, B}
     end
 end
 
+"""
+    Ones{T}
+
+Implicit length n vector of ones of type `T`
+
+# Members
+- `n`: length
+"""
+struct Ones{T} <: AbstractVector{T}
+    n::Int
+end
+
+Base.size(v::Ones) = (v.n,)
+function Base.getindex(v::Ones{T}, i) where T
+    0 < i ≤ v.n || throw(BoundsError("attempt to access $(v.n)-element Ones at index [$i]"))
+    one(T)
+end
+
+Base.length(v::Ones) = v.n
+
+Base.scale!(v::AbstractVector, z::Ones, a::AbstractVector) = copy!(v, a)
 
 """
     OptSummary
@@ -140,7 +161,7 @@ struct LinearMixedModel{T <: AbstractFloat} <: MixedModel{T}
     trms::Vector{AbstractTerm{T}}
     sqrtwts::Vector{T}
     A::BlockMatrix{T}            # cross-product blocks
-    L::BlockMatrix{T}
+    L::LowerTriangular{T,BlockArray{T,2,AbstractMatrix{T}}}
     optsum::OptSummary{T}
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -36,28 +36,6 @@ function Base.getindex(A::UniformBlockDiagonal{T,B}, i::Int, j::Int) where {T, B
 end
 
 """
-    Ones{T}
-
-Implicit length n vector of ones of type `T`
-
-# Members
-- `n`: length
-"""
-struct Ones{T} <: AbstractVector{T}
-    n::Int
-end
-
-Base.size(v::Ones) = (v.n,)
-function Base.getindex(v::Ones{T}, i) where T
-    0 < i ≤ v.n || throw(BoundsError("attempt to access $(v.n)-element Ones at index [$i]"))
-    one(T)
-end
-
-Base.length(v::Ones) = v.n
-
-Base.scale!(v::AbstractVector, z::Ones, a::AbstractVector) = copy!(v, a)
-
-"""
     OptSummary
 
 Summary of an `NLopt` optimization

--- a/src/types.jl
+++ b/src/types.jl
@@ -60,6 +60,8 @@ function Base.full(A::UniformBlockDiagonal{T}) where T
         for j = 1:n, i = 1:m
             res[offseti + i, offsetj + j] = Ad[i, j, k]
         end
+        offseti += m
+        offsetj += n
     end
     res
 end

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -110,12 +110,14 @@ end
     end
 
     @test vec(corr'MatrixTerm(ones(size(corr, 1)))) == repeat([10.0, 45.0], outer = 18)
-#=
+
     vrp = corr'corr
     
-    @test isa(vrp, UniformBlockDiagonal{Float64,2,4})
+    @test isa(vrp, UniformBlockDiagonal{Float64})
     @test size(vrp) == (36, 36)
-=#
+
+    @test MixedModels.Λ_mul_B!(Vector{Float64}(36), corr, ones(36)) == repeat([0.5, 1.0], outer=18)
+    
     @testset "reweight!" begin
         wts = rand(MersenneTwister(1234321), size(corr, 1))
         @test MixedModels.reweight!(corr, wts).wtz[1, :] == wts

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -7,9 +7,9 @@ end
 @testset "scalarRe" begin
     dyestuff = dat[:Dyestuff]
     pastes = dat[:Pastes]
-    sf = FactorReTerm(dyestuff[:G])
-    sf1 = FactorReTerm(pastes[:G])
-    sf2 = FactorReTerm(pastes[:H])
+    sf = ScalarFactorReTerm(dyestuff[:G])
+    sf1 = ScalarFactorReTerm(pastes[:G])
+    sf2 = ScalarFactorReTerm(pastes[:H])
     Yield = Array(dyestuff[:Y])
 
     @testset "size" begin
@@ -112,7 +112,7 @@ end
     @test vec(corr'MatrixTerm(ones(size(corr, 1)))) == repeat([10.0, 45.0], outer = 18)
 
     vrp = corr'corr
-    @test isa(vrp, HomoBlockDiagonal{Float64,2,4})
+    @test isa(vrp, UniformBlockDiagonal{Float64,2,4})
     @test size(vrp) == (36, 36)
 
     @testset "reweight!" begin

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -112,9 +112,8 @@ end
     @test vec(corr'MatrixTerm(ones(size(corr, 1)))) == repeat([10.0, 45.0], outer = 18)
 
     vrp = corr'corr
-    @test isa(vrp, MixedModels.Diagonal{Matrix{Float64}})
-    @test eltype(vrp) == Matrix{Float64}
-    @test size(vrp) == (18, 18)
+    @test isa(vrp, HomoBlockDiagonal{Float64,2,4})
+    @test size(vrp) == (36, 36)
 
     @testset "reweight!" begin
         wts = rand(MersenneTwister(1234321), size(corr, 1))

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -110,12 +110,12 @@ end
     end
 
     @test vec(corr'MatrixTerm(ones(size(corr, 1)))) == repeat([10.0, 45.0], outer = 18)
-
+#=
     vrp = corr'corr
     
     @test isa(vrp, UniformBlockDiagonal{Float64,2,4})
     @test size(vrp) == (36, 36)
-
+=#
     @testset "reweight!" begin
         wts = rand(MersenneTwister(1234321), size(corr, 1))
         @test MixedModels.reweight!(corr, wts).wtz[1, :] == wts

--- a/test/UniformBlockDiagonal.jl
+++ b/test/UniformBlockDiagonal.jl
@@ -1,0 +1,21 @@
+using Base.Test, MixedModels
+
+const ex22 = UniformBlockDiagonal([reshape(collect(1:4) + k, (2, 2)) for k in 0:4:8])
+
+@testset "size" begin
+    @test size(ex22) == (6, 6)
+    @test size(ex22, 1) == 6
+    @test size(ex22, 2) == 6
+    @test size(ex22.data) == (2, 2, 3)
+    @test length(ex22.facevec) == 3
+end
+
+@testset "elements" begin
+    @test ex22[1, 1] == 1
+    @test ex22[2, 1] == 2
+    @test ex22[3, 1] == 0
+    @test ex22[2, 2] == 4
+    @test ex22[3, 3] == 5
+    @test ex22[:, 3] == [0,0,5,6,0,0]
+    @test ex22[5, 6] == 11
+end

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -1,4 +1,4 @@
-using Base.Test, RData, MixedModels
+using Base.Test, DataFrames, RData, MixedModels
 
 if !isdefined(:dat) || !isa(dat, Dict{Symbol, Any})
     dat = convert(Dict{Symbol,Any}, load(joinpath(dirname(@__FILE__), "dat.rda")))

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -50,6 +50,7 @@ end
     @test isapprox(sum(gm3.resp.devresid), 7156.558983084621, atol=0.1)
 end
 
+if false # still missing a method needed here
 @testset "grouseticks" begin
     gm4 = fit!(glmm(@formula(t ~ 1 + y + ch + (1|i) + (1|b) + (1|l)), dat[:grouseticks],
                     Poisson()))
@@ -58,4 +59,5 @@ end
     # these two values are not well defined at the optimum
     @test isapprox(sum(x -> sum(abs2, x), gm4.u), 196.8695297987013, atol=0.1)
     @test isapprox(sum(gm4.resp.devresid), 220.92685781326136, atol=0.1)
+end
 end

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -9,7 +9,7 @@ end
     contraception[:a2] = abs2.(contraception[:a])
     contraception[:urbdist] = string.(contraception[:urb], contraception[:d])
     gm0 = fit!(glmm(@formula(use ~ 1 + a + a2 + urb + l + (1 | urbdist)), contraception,
-        Bernoulli()), fast = true);
+                    Bernoulli()), fast = true);
     @test isapprox(getθ(gm0)[1], 0.5720734451352923, atol=0.001)
     @test isapprox(LaplaceDeviance(gm0), 2361.657188518064, atol=0.001)
     gm1 = fit!(glmm(@formula(use ~ 1 + a + a2 + urb + l + (1 | urbdist)), contraception,
@@ -29,7 +29,7 @@ end
     cbpp = dat[:cbpp]
     cbpp[:prop] = cbpp[:i] ./ cbpp[:s]
     gm2 = fit!(glmm(@formula(prop ~ 1 + p + (1 | h)), cbpp, Binomial(),
-        wt = Array(cbpp[:s])));
+                    wt = Array(cbpp[:s])));
     @test isapprox(LaplaceDeviance(gm2), 100.09585619324639, atol=0.0001)
     @test isapprox(sum(abs2, gm2.u[1]), 9.723175126731014, atol=0.0001)
     @test isapprox(logdet(gm2), 16.90113, atol=0.0001)
@@ -41,7 +41,8 @@ end
 
 @testset "verbagg" begin
     verbagg = dat[:VerbAgg]
-    gm3 = fit!(glmm(@formula(r2 ~ 1 + a + g + b + s + (1 | id) + (1 | item)), verbagg, Bernoulli()));
+    gm3 = fit!(glmm(@formula(r2 ~ 1 + a + g + b + s + (1 | id) + (1 | item)), verbagg,
+                    Bernoulli()));
     @test isapprox(LaplaceDeviance(gm3), 8151.39972809092, atol=0.001)
     @test lowerbd(gm3) == vcat(fill(-Inf, 6), zeros(2))
     # these two values are not well defined at the optimum
@@ -50,7 +51,8 @@ end
 end
 
 @testset "grouseticks" begin
-    gm4 = fit!(glmm(@formula(t ~ 1 + y + ch + (1|i) + (1|b) + (1|l)), dat[:grouseticks], Poisson()))
+    gm4 = fit!(glmm(@formula(t ~ 1 + y + ch + (1|i) + (1|b) + (1|l)), dat[:grouseticks],
+                    Poisson()))
     @test isapprox(LaplaceDeviance(gm4), 849.5439802900257, atol=0.001)
     @test lowerbd(gm4) == vcat(fill(-Inf, 4), zeros(3))
     # these two values are not well defined at the optimum

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -142,9 +142,8 @@ end
     updateL!(fm);
     b11 = LowerTriangular(fm.L.data[Block(1, 1)].facevec[1])
     @test b11 * b11' == fm.A[Block(1, 1)].facevec[1] + I
-#=   Not sure this test is meaningful anymore
-    @test countnz(full(fm.L[1, 1])) == 18 * 3
-=#
+    @test countnz(full(fm.L.data[Block(1, 1)])) == 18 * 4
+
 
     fit!(fm)
 
@@ -196,7 +195,6 @@ end
     MixedModels.lrt(fm, fmnc)
 end
 
-# takes too long for Travis
 @testset "d3" begin
     fm = updateL!(lmm(@formula(Y ~ 1 + U + (1+U|G) + (1+U|H) + (1+U|I)), dat[:d3]));
     @test isapprox(pwrss(fm), 5.1261847180180885e6, rtol = 1e-6)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -196,7 +196,7 @@ end
     MixedModels.lrt(fm, fmnc)
 end
 
-if false  # takes too long for Travis
+# takes too long for Travis
 @testset "d3" begin
     fm = updateL!(lmm(@formula(Y ~ 1 + U + (1+U|G) + (1+U|H) + (1+U|I)), dat[:d3]));
     @test isapprox(pwrss(fm), 5.1261847180180885e6, rtol = 1e-6)
@@ -205,7 +205,6 @@ if false  # takes too long for Travis
     fit!(fm)
     @test isapprox(objective(fm), 884957.5540213, rtol = 1e-6)
     @test isapprox(fixef(fm), [0.499130440264, 0.31130685058], atol = 1.e-5)
-end
 end
 
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -9,10 +9,10 @@ end
 
     @test nblocks(fm1.A) == (3, 3)
     @test size(fm1.trms) == (3, )
-    @test nblocks(fm1.L) == (3, 3)
+    @test nblocks(fm1.L.data) == (3, 3)
     @test lowerbd(fm1) == zeros(1)
     @test getθ(fm1) == ones(1)
-    @test getΛ(fm1) == Matrix[ones(1,1)]
+    @test getΛ(fm1) == 1.0
 
     @test objective(updateL!(setθ!(fm1, [0.713]))) ≈ 327.34216280955366
     MixedModels.describeblocks(IOBuffer(), fm1)
@@ -136,9 +136,9 @@ end
     fm = lmm(@formula(Y ~ 1 + U + (1 + U | G)), dat[:sleepstudy]);
     @test lowerbd(fm) == [0.0, -Inf, 0.0]
     A11 = fm.A[Block(1,1)]
-    @test isa(A11, HomoBlockDiagonal{Float64, 2, 4})
-    @test isa(fm.L[Block(1, 1)], LowerTriangular{Float64, HomoBlockDiagonal{Float64, 2, 4}})
-    @test size(A11) = (36, 36)
+    @test isa(A11, UniformBlockDiagonal{Float64, 2, 4})
+    @test isa(fm.L.data[Block(1, 1)], UniformBlockDiagonal{Float64, 2, 4})
+    @test size(A11) == (36, 36)
     @test A11.data[1] == [10. 45.; 45. 285.]
     @test length(A11.data) == 18
     updateL!(fm);

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -109,7 +109,6 @@ end
     @test isapprox(logdet(fm), 101.0381339953986, atol=0.001)
 end
 
-if false # takes too long on Travis for julia 0.6
 @testset "InstEval" begin
     fm1 = lmm(@formula(Y ~ 1 + A + (1 | G) + (1 | H) + (1 | I)), dat[:InstEval])
     @test size(fm1) == (73421, 2, 4114, 3)
@@ -130,9 +129,9 @@ if false # takes too long on Travis for julia 0.6
     @test isapprox(objective(fm2), 237585.5534151694, atol=0.001)
     @test size(fm2) == (73421, 28, 4100, 2)
 end
-end
 
-@testset "sleep" begin
+if false # takes too long on Travis for julia 0.6
+    @testset "sleep" begin
     fm = lmm(@formula(Y ~ 1 + U + (1 + U | G)), dat[:sleepstudy]);
     @test lowerbd(fm) == [0.0, -Inf, 0.0]
     A11 = fm.A[Block(1,1)]
@@ -193,6 +192,7 @@ end
     cor(fmnc)
 
     MixedModels.lrt(fm, fmnc)
+end
 end
 
 if false  # takes too long for Travis

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -1,4 +1,4 @@
-using Base.Test, RData, StatsBase, MixedModels
+using Base.Test, StatsBase, DataFrames, RData, MixedModels
 
 if !isdefined(:dat) || !isa(dat, Dict{Symbol, Any})
     dat = convert(Dict{Symbol,Any}, load(joinpath(dirname(@__FILE__), "dat.rda")))
@@ -12,7 +12,7 @@ end
     @test nblocks(fm1.L.data) == (3, 3)
     @test lowerbd(fm1) == zeros(1)
     @test getθ(fm1) == ones(1)
-    @test getΛ(fm1) == 1.0
+    @test getΛ(fm1) == [1.0]
 
     @test objective(updateL!(setθ!(fm1, [0.713]))) ≈ 327.34216280955366
     MixedModels.describeblocks(IOBuffer(), fm1)

--- a/test/rankUpdate.jl
+++ b/test/rankUpdate.jl
@@ -1,0 +1,6 @@
+using Base.Test, MixedModels
+
+# methods that are not otherwise tested
+@testset "rankUpdate" begin
+    @test ones(2, 2) == MixedModels.rankUpdate!(1.0, ones(2), Hermitian(zeros(2, 2)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DataArrays, DataFrames, MixedModels, RData, Base.Test
 
 const dat = convert(Dict{Symbol,Any},load(joinpath(dirname(@__FILE__), "dat.rda")))
 
+include("UniformBlockDiagonal.jl")
 include("matrixterm.jl")
 include("FactorReTerm.jl")
 include("pls.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using DataArrays, DataFrames, MixedModels, RData, Base.Test
 
 const dat = convert(Dict{Symbol,Any},load(joinpath(dirname(@__FILE__), "dat.rda")))
 
+include("rankUpdate.jl")
 include("UniformBlockDiagonal.jl")
 include("matrixterm.jl")
 include("FactorReTerm.jl")


### PR DESCRIPTION
- Switch to `BlockArray` types for the penalized least squares problem
- Distinguish between `ScalarFactorReTerm` and `VectorFactorReTerm`
- Use `UniformBlockDiagonal` type for diagonal blocks from `VectorFactorReTerm`
- More benchmarks
