### PR TITLE
Reorder arguments in mul! and rankUpdate! methods

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,10 +1,11 @@
-function αβA_mul_Bc!(α::T, A::StridedMatrix{T}, B::StridedMatrix{T},
-                     β::T, C::StridedMatrix{T}) where T <: BlasFloat
-    BLAS.gemm!('N', 'C', α, A, B, β, C)
+function mulαβ!(C::StridedMatrix{T}, A::StridedMatrix{T}, 
+        adjB::Adjoint{T,<:StridedMatrix{T}}, α=true, β=false) where {T<:BlasFloat}
+    BLAS.gemm!('N', 'C', T(α), A, adjB.parent, T(β), C)
 end
 
-function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T},
-                     β::T, C::Matrix{T}) where T <: Number
+function mulαβ!(C::Matrix{T}, A::SparseMatrixCSC{T}, adjB::Adjoint{T,<:SparseMatrixCSC{T}},
+        α=true, β=false) where T <: Number
+    B = adjB.parent
     @argcheck(B.m == size(C, 2) && A.m == size(C, 1) && A.n == B.n, DimensionMismatch)
     anz = nonzeros(A)
     arv = rowvals(A)
@@ -23,11 +24,12 @@ function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T},
     C
 end
 
-αβA_mul_Bc!(α::T, A::BlockedSparse{T}, B::BlockedSparse{T}, β::T, C::Matrix{T}) where {T} =
-    αβA_mul_Bc!(α, A.cscmat, B.cscmat, β, C)
+mulαβ!(C::Matrix{T}, A::BlockedSparse{T}, adjB::Adjoint{T,<:BlockedSparse{T}}, α=true, β=false) where {T} =
+    mulαβ!(C, A.cscmat, adjB.parent.cscmat', α, β)
 
-function αβA_mul_Bc!(α::T, A::StridedVecOrMat{T}, B::SparseMatrixCSC{T}, β::T,
-                     C::StridedVecOrMat{T}) where T
+function mulαβ!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, adjB::Adjoint{T,<:SparseMatrixCSC{T}},
+        α=true, β=false) where T
+    B = adjB.parent
     m, n = size(A)
     p, q = size(B)
     r, s = size(C)
@@ -45,19 +47,21 @@ function αβA_mul_Bc!(α::T, A::StridedVecOrMat{T}, B::SparseMatrixCSC{T}, β::
     C
 end
 
-αβA_mul_Bc!(α::T, A::StridedVecOrMat{T}, B::BlockedSparse{T}, β::T,
-            C::StridedVecOrMat{T}) where {T} = αβA_mul_Bc!(α, A, B.cscmat, β, C)
+mulαβ!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, adjB::Adjoint{T,<:BlockedSparse{T}},
+    α=true, β=false) where {T} = mulαβ!(C, A, adjB.parent.cscmat', α, β)
 
-αβAc_mul_B!(α::T, A::StridedMatrix{T}, B::StridedVector{T}, β::T,
-            C::StridedVector{T}) where {T<:BlasFloat} = BLAS.gemv!('C', α, A, B, β, C)
+mulαβ!(C::StridedVector{T}, adjA::Adjoint{T,<:StridedMatrix{T}}, B::StridedVector{T},
+        α=true, β=false) where {T<:BlasFloat} = BLAS.gemv!('C', T(α), adjA.parent, B, T(β), C)
 
-αβAc_mul_B!(α::T, A::SparseMatrixCSC{T}, B::StridedVector{T}, β::T,
-            C::StridedVector{T}) where {T} = mul!(C, adjoint(A), B, α, β)
+mulαβ!( C::StridedVector{T}, adjA::Adjoint{T,<:SparseMatrixCSC{T}}, B::StridedVector{T},
+        α=true, β=false) where {T} = mul!(C, adjA, B, T(α), T(β))
 
-αβAc_mul_B!(α::T, A::BlockedSparse{T}, B::StridedVector{T}, β::T,
-            C::StridedVector{T}) where {T} = αβAc_mul_B!(α, A.cscmat, B, β, C)
+mulαβ!(C::StridedVector{T}, adjA::Adjoint{T,<:BlockedSparse{T}}, B::StridedVector{T},
+        α=true, β=false) where {T} = mulαβ!(α, adjA.parent.cscmat', B, β, C)
 
-function αβA_mul_Bc!(α::T, A::SparseMatrixCSC{T}, B::SparseMatrixCSC{T}, β::T, C::SparseMatrixCSC{T}) where {T}
+function mulαβ!(C::SparseMatrixCSC{T}, A::SparseMatrixCSC{T}, adjB::Adjoint{T,<:SparseMatrixCSC{T}},
+        α=true, β=false) where {T}
+    B = adjB.parent
     @argcheck(C.m == A.m && C.n == B.m && A.n == B.n, DimensionMismatch)
     Anz = nonzeros(A)
     Bnz = nonzeros(B)
@@ -120,6 +124,8 @@ function LinearAlgebra.rdiv!(A::BlockedSparse{T}, B::Adjoint{T,<:LowerTriangular
     A
 end
 
+## Note: remove these method definitions once a new version of the LinearAlgebra standard package is released
+## Not yet sure what condition to use 
 LinearAlgebra.mul!(C::AbstractVecOrMat, A::AbstractVecOrMat, J::UniformScaling) = mul!(C, A, J.λ)
 
 LinearAlgebra.mul!(C::AbstractVecOrMat, J::UniformScaling, B::AbstractVecOrMat) = mul!(C, J.λ, B)

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -115,15 +115,15 @@ function ranef!(v::Vector, m::LinearMixedModel{T}, β::AbstractArray{T}, uscale:
     Ldat = m.L.data
     @argcheck((k = length(v)) == nreterms(m), DimensionMismatch)
     for j in 1:k
-        αβAc_mul_B!(-one(T), Ldat[Block(k + 1, j)], β, one(T),
-                    vec(copyto!(v[j], Ldat[Block(nblocks(Ldat, 2), j)])))
+        mulαβ!(vec(copyto!(v[j], Ldat[Block(nblocks(Ldat, 2), j)])), Ldat[Block(k + 1, j)]', β,
+            -one(T), one(T))
     end
     for i in k: -1 :1
         Lii = Ldat[Block(i, i)]
         vi = vec(v[i])
         ldiv!(adjoint(isa(Lii, Diagonal) ? Lii : LowerTriangular(Lii)), vi)
         for j in 1:(i - 1)
-            αβAc_mul_B!(-one(T), Ldat[Block(i, j)], vi, one(T), vec(v[j]))
+            mulαβ!(vec(v[j]), Ldat[Block(i, j)]', vi, -one(T), one(T))
         end
     end
     if !uscale

--- a/src/modelterms.jl
+++ b/src/modelterms.jl
@@ -132,7 +132,7 @@ function reweight!(A::ScalarFactorReTerm, sqrtwts::Vector)
         if A.z == A.wtz
             A.wtz = A.z .* sqrtwts
         else
-            A.wtz .= A.z .* sqrtwts
+            mul!(A.wtz, Diagonal(sqrtwts), A.z)
         end
     end
     A
@@ -206,7 +206,7 @@ function reweight!(A::VectorFactorReTerm{T,R,S}, sqrtwts::Vector) where {T,R,S}
             A.wtz = copy(z)
             A.wtzv = reinterpret(SVector{S,T}, vec(A.wtz))
         end
-        A.wtz .= z * Diagonal(sqrtwts)
+        mul!(A.wtz, z, Diagonal(sqrtwts))
     end
     A
 end

--- a/src/pls.jl
+++ b/src/pls.jl
@@ -135,13 +135,13 @@ function updateL!(m::LinearMixedModel{T}) where T
         Ljj = scaleInflate!(Ldat[Block(j, j)], A[Block(j, j)], trms[j])
         LjjH = isa(Ljj, Diagonal) ? Ljj : Hermitian(Ljj, :L)
         for jj in 1:(j - 1)
-            rankUpdate!(-one(T), Ldat[Block(j, jj)], LjjH)
+            rankUpdate!(LjjH, Ldat[Block(j, jj)], -one(T))
         end
         cholUnblocked!(Ljj, Val{:L})
         for i in (j + 1):nblk
             Lij = lmul!(Λ(trms[i])', rmul!(copyto!(Ldat[Block(i, j)], A[Block(i, j)]), Λ(trms[j])))
             for jj in 1:(j - 1)
-                αβA_mul_Bc!(-one(T), Ldat[Block(i, jj)], Ldat[Block(j, jj)], one(T), Lij)
+                mulαβ!(Lij, Ldat[Block(i, jj)], Ldat[Block(j, jj)]', -one(T), one(T))
             end
             rdiv!(Lij, isa(Ljj, Diagonal) ? Ljj : LowerTriangular(Ljj)')
         end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -183,24 +183,21 @@ function unscaledre!(y::AbstractVector, A::ScalarFactorReTerm, b::AbstractVecOrM
     m, n = size(A)
     @argcheck(length(y) == m && length(b) == n, DimensionMismatch)
     z = A.z
-    r = A.refs
-    for i in eachindex(r)
-        y[i] += b[r[i]] * z[i]
+    for (i, r) in enumerate(A.refs)
+        y[i] += b[r] * z[i]
     end
     y
 end
 
-function unscaledre!(y::AbstractVector{T}, A::VectorFactorReTerm{T,V,R},
-                     b::DenseMatrix) where {T,V,R}
+function unscaledre!(y::AbstractVector{T}, A::VectorFactorReTerm{T,R,S},
+                     b::DenseMatrix) where {T,R,S}
     Z = A.z
     k, n = size(Z)
     l = nlevs(A)
-    @argcheck length(y) == n && size(b) == (k, l) DimensionMismatch
-    inds = A.refs
-    for i in eachindex(y)
-        ii = inds[i]
+    @argcheck(length(y) == n && size(b) == (k, l), DimensionMismatch)
+    for (i, ii) in enumerate(A.refs)
         for j in 1:k
-            y[i] += Z[j,i] * b[j, ii]
+            y[i] += Z[j, i] * b[j, ii]
         end
     end
     y

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,32 +21,31 @@ function Base.size(A::UniformBlockDiagonal)
 end
 
 function Base.getindex(A::UniformBlockDiagonal{T}, i::Int, j::Int) where {T}
-    m, n, l = size(A.data)
+    Ad = A.data
+    m, n, l = size(Ad)
     (0 < i ≤ l * m && 0 < j ≤ l * n) ||
         throw(IndexError("attempt to access $(l*m) × $(l*n) array at index [$i, $j]"))
     iblk, ioffset = divrem(i - 1, m)
     jblk, joffset = divrem(j - 1, n)
-    if iblk == jblk
-        A.data[ioffset+1, joffset+1, iblk+1]
-    else
-        zero(T)
-    end
+    iblk == jblk ? Ad[ioffset+1, joffset+1, iblk+1] : zero(T)
 end
 
 function LinearAlgebra.Matrix(A::UniformBlockDiagonal{T}) where T
-    res = zeros(T, size(A))
     Ad = A.data
     m, n, l = size(Ad)
-    offseti = 0
-    offsetj = 0
-    for k = 1:l
-        for j = 1:n, i = 1:m
-            res[offseti + i, offsetj + j] = Ad[i, j, k]
+    mat = zeros(T, (m*l, n*l))
+    for k = 0:(l-1)
+        kp1 = k + 1
+        km = k * m
+        kn = k * n
+        for j = 1:n
+            knpj = kn + j
+            for i = 1:m
+                mat[km + i, knpj] = Ad[i, j, kp1]
+            end
         end
-        offseti += m
-        offsetj += n
     end
-    res
+    mat
 end
 
 """
@@ -82,28 +81,25 @@ function Base.getindex(A::RepeatedBlockDiagonal{T}, i::Int, j::Int) where {T}
         throw(IndexError("attempt to access $(nb*m) × $(nb*n) array at index [$i, $j]"))
     iblk, ioffset = divrem(i - 1, m)
     jblk, joffset = divrem(j - 1, n)
-    if iblk == jblk
-        A.data[ioffset+1, joffset+1]
-    else
-        zero(T)
-    end
+    iblk == jblk ? A.data[ioffset+1, joffset+1] : zero(T)
 end
 
 function LinearAlgebra.Matrix(A::RepeatedBlockDiagonal{T}) where T
-    res = zeros(T, size(A))
+    mat = zeros(T, size(A))
     Ad = A.data
     m, n = size(Ad)
     nb = A.nblocks
-    offseti = 0
-    offsetj = 0
-    for k = 1:nb
-        for j = 1:n, i = 1:m
-            res[offseti + i, offsetj + j] = Ad[i, j]
+    for k = 0:(nb-1)
+        km = k * m
+        kn = k * n
+        for j = 1:n
+            knpj = kn + j
+            for i = 1:m
+                mat[km + i, knpj] = Ad[i, j]
+            end
         end
-        offseti += m
-        offsetj += n
     end
-    res
+    mat
 end
 
 """
@@ -130,14 +126,14 @@ Base.size(A::BlockedSparse, d) = size(A.cscmat, d)
 
 Base.getindex(A::BlockedSparse{T}, i::Integer, j::Integer) where {T} = getindex(A.cscmat, i, j)
 
-LinearAlgebra.Matrix(A::BlockedSparse{T}) where {T} = full(A.cscmat)
+LinearAlgebra.Matrix(A::BlockedSparse{T}) where {T} = Matrix(A.cscmat)
 
 SparseArrays.sparse(A::BlockedSparse) = A.cscmat
 
 SparseArrays.nnz(A::BlockedSparse) = nnz(A.cscmat)
 
 function Base.copyto!(L::BlockedSparse{T,I}, A::SparseMatrixCSC{T,I}) where {T,I}
-    @argcheck(nnz(L) == nnz(A), DimensionMismatch)
+    @argcheck(size(L) == size(A) && nnz(L) == nnz(A), DimensionMismatch)
     copyto!(nonzeros(L.cscmat), nonzeros(A))
     L
 end
@@ -147,7 +143,8 @@ end
 
 Summary of an `NLopt` optimization
 
-# Members
+# Fields
+
 * `initial`: a copy of the initial parameter values in the optimization
 * `lowerbd`: lower bounds on the parameter values
 * `ftol_rel`: as in NLopt
@@ -161,6 +158,9 @@ Summary of an `NLopt` optimization
 * `feval`: the number of function evaluations
 * `optimizer`: the name of the optimizer used, as a `Symbol`
 * `returnvalue`: the return value, as a `Symbol`
+* `nAGQ`: number of adaptive Gauss-Hermite quadrature points in deviance evaluation for GLMMs
+
+The latter field doesn't really belong here but it has to be in a mutable struct in case it is changed.
 """
 mutable struct OptSummary{T <: AbstractFloat}
     initial::Vector{T}
@@ -237,7 +237,7 @@ Linear mixed-effects model representation
 ## Fields
 
 * `formula`: the formula for the model
-* `trms`: a `Vector{AbstractTerm}` representing the model.  The last element is the response.
+* `trms`: a `Vector` of `AbstractTerm` types representing the model.  The last element is the response.
 * `sqrtwts`: vector of square roots of the case weights.  Can be empty.
 * `A`: an `nt × nt` symmetric `BlockMatrix` of matrices representing `hcat(Z,X,y)'hcat(Z,X,y)`
 * `L`: a `nt × nt` `BlockMatrix` - the lower Cholesky factor of `Λ'AΛ+I`
@@ -257,7 +257,7 @@ Linear mixed-effects model representation
 """
 struct LinearMixedModel{T <: AbstractFloat} <: MixedModel{T}
     formula::Formula
-    trms::Vector{AbstractTerm{T}}
+    trms::Vector
     sqrtwts::Vector{T}
     A::BlockMatrix{T}            # cross-product blocks
     L::LowerTriangular{T,BlockArray{T,2,AbstractMatrix{T}}}

--- a/test/UniformBlockDiagonal.jl
+++ b/test/UniformBlockDiagonal.jl
@@ -53,7 +53,7 @@ end
     end
 
     @testset "updateL" begin
-        @test ones(2, 2) == MixedModels.rankUpdate!(1.0, ones(2), Hermitian(zeros(2, 2)))
+        @test ones(2, 2) == MixedModels.rankUpdate!(Hermitian(zeros(2, 2)), ones(2))
         d3 = dat[:d3]
         modelmat = ones(2, size(d3, 1))
         copyto!(view(modelmat, 2, :), d3[:U])


### PR DESCRIPTION
* change methods for `αβA_mul_Bc!` and `αβAc_mul_B!` to methods for `mulαβ!` 
* put the argument to be modified first in `mulαβ!`
* put scalar arguments, `α` and `β`, last so they can be given defaults
* default arguments for scalars are `Bool`s, `true` and `false`, which are "hard zeros and ones"
* change argument order in `rankUpdate!` so argument to be modified is first
* clean up code in some methods for `UniformBlockDiagonal` and `RepeatedBlockDiagonal`