### PR TITLE
convert info to BlasInt in Cholesky(::LowerTriangular)

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -124,7 +124,7 @@ function LinearAlgebra.Cholesky(L::LowerTriangular)  # FIXME: this is type pirac
             break
         end
     end
-    Cholesky(L, 'L', info)
+    Cholesky(L, 'L', LinearAlgebra.BlasInt(info))
 end
 
 """


### PR DESCRIPTION
Fixes #143 by manually converting the system `Int` to `LinearAlgebra.BlasInt` which may not be the same on some system BLAS (like arch linux).