### PR TITLE
use MatrixTerm/is_matrix_term to separate fixed and ranef terms

### DIFF
--- a/src/newterms.jl
+++ b/src/newterms.jl
@@ -52,9 +52,12 @@ struct RandomEffectsTerm <: AbstractTerm
     rhs::CategoricalTerm
 end
 
+Base.show(io::IO, t::RandomEffectsTerm) = print(io, "($(t.lhs) | $(t.rhs))")
+StatsModels.is_matrix_term(::Type{RandomEffectsTerm}) = false
+
 function apply_schema(t::FunctionTerm{typeof(|)}, schema, Mod::Type{<:MixedModel})
     lhs, rhs = apply_schema.(t.args_parsed, Ref(schema), Mod)
-    RandomEffectsTerm(isa(lhs, Tuple) ? apply_schema.(lhs, Ref(schema), Mod) : lhs, rhs)
+    RandomEffectsTerm(MatrixTerm(lhs), rhs)
 end
 
 StatsModels.termnames(t::RandomEffectsTerm) = string(t.rhs.sym)


### PR DESCRIPTION
I've moved all the logic for separating "matrix terms" (here fixed effects) and "non-matrix terms" (like random effects) into statsmodels in the latest commits.  Those also introduced a `MatrixTerm` that explicitly marks its children terms for concatenation at the `model_cols` stage (and guarantees that it produces a matrix) which also simplifies the code here somewhat