### PR TITLE
Update metadata

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MixedModels package is licensed under the MIT License:
 
-> Copyright (c) 2013-2014: Douglas Bates
+> Copyright (c) 2013-2018: Douglas Bates
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the
@@ -9,10 +9,10 @@ The MixedModels package is licensed under the MIT License:
 > distribute, sublicense, and/or sell copies of the Software, and to
 > permit persons to whom the Software is furnished to do so, subject to
 > the following conditions:
-> 
+>
 > The above copyright notice and this permission notice shall be
 > included in all copies or substantial portions of the Software.
-> 
+>
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 > EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 > MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/README.md
+++ b/README.md
@@ -1,30 +1,11 @@
 # Mixed-effects models in Julia
 
-| **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
-|:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][coveralls-img]][coveralls-url] [![][codecov-img]][codecov-url] |
+|**Documentation**|**Citation**|**Build Status**|**Code Coverage**|
+|:-:|:-:|:-:|:-:|
+|[![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][doi-img]][doi-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] | [![][coveralls-img]][coveralls-url] [![][codecov-img]][codecov-url]|
 
-[![DOI](https://zenodo.org/badge/9106942.svg)](https://zenodo.org/badge/latestdoi/9106942)
-
-## Installation
-
-The package is registered in `METADATA.jl` and can be installed using `Pkg.add` or in the `Pkg` REPL, entered by typing `]` as the first character in a line.
-
-```julia
-(v1.0) pkg> add MixedModels
-  Updating registry at `~/.julia/registries/General`
-  Updating git-repo `https://github.com/JuliaRegistries/General.git`
- Resolving package versions...
-  Updating `~/.julia/environments/v1.0/Project.toml`
- [no changes]
-  Updating `~/.julia/environments/v1.0/Manifest.toml`
- [no changes]
-```
-
-The package provides the functions `lmm`, to create a linear mixed-effects model
-from a formula/data specification, and `glmm` to create a generalized linear
-mixed-effects model.  See [the documentation](http://dmbates.github.io/MixedModels.jl/latest)
-for details.
+[doi-img]: https://zenodo.org/badge/9106942.svg
+[doi-url]: https://zenodo.org/badge/latestdoi/9106942
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://dmbates.github.io/MixedModels.jl/latest
@@ -43,10 +24,3 @@ for details.
 
 [codecov-img]: https://codecov.io/github/dmbates/MixedModels.jl/badge.svg?branch=master
 [codecov-url]: https://codecov.io/github/dmbates/MixedModels.jl?branch=master
-
-[issues-url]: https://github.com/dmbates/MixedModels.jl/issues
-
-[pkg-0.7-img]: http://pkg.julialang.org/badges/MixedModels_0.7.svg
-[pkg-0.7-url]: http://pkg.julialang.org/?pkg=MixedModels
-[pkg-1.0-img]: http://pkg.julialang.org/badges/MixedModels_1.0.svg
-[pkg-1.0-url]: http://pkg.julialang.org/?pkg=MixedModels


### PR DESCRIPTION
License: Update year
README:
- drop PkgEval since it has been deprecated for 0.7/1.0
- Drop reference for `lmm` and `glmm` as documentation favors using the `fit` with the type
- Drop the installation quickstart since package is registered