### PR TITLE
Add the `zerocorr!` function, tests and documentation.

### DIFF
--- a/docs/jmd/constructors.jmd
+++ b/docs/jmd/constructors.jmd
@@ -12,7 +12,7 @@ For illustration, several data sets from the *lme4* package for *R* are made ava
 These include the `Dyestuff` and `Dyestuff2` data sets.
 ```{julia;term=true}
 using DataFrames, MixedModels, RData, StatsBase
-const dat = Dict(Symbol(k)=>v for (k,v) in 
+const dat = Dict(Symbol(k)=>v for (k,v) in
     load(joinpath(dirname(pathof(MixedModels)), "..", "test", "dat.rda")));
 describe(dat[:Dyestuff])
 ```
@@ -31,16 +31,20 @@ A basic model with simple, scalar random effects for the levels of `G` (the batc
 fm1 = fit!(LinearMixedModel(@formula(Y ~ 1 + (1|G)), dat[:Dyestuff]))
 ```
 
+An alternative expression is
+```{julia;term=true}
+fm1 = fit(MixedModel, @formula(Y ~ 1 + (1|G)), dat[:Dyestuff])
+```
 (If you are new to Julia you may find that this first fit takes an unexpectedly long time, due to Just-In-Time (JIT) compilation of the code.
 The second and subsequent calls to such functions are much faster.)
 
 ```{julia;term=true}
-@time fit!(LinearMixedModel(@formula(Y ~ 1 + (1|G)), dat[:Dyestuff2]));
+@time fit(MixedModel, @formula(Y ~ 1 + (1|G)), dat[:Dyestuff2]);
 ```
 
 By default, the model fit is by maximum likelihood.  To use the `REML` criterion instead, add the optional named argument `REML = true` to the call to `fit!`
 ```{julia;term=true}
-fm1R = fit!(LinearMixedModel(@formula(Y ~ 1 + (1|G)), dat[:Dyestuff]), REML=true)
+fm1R = fit(MixedModel, @formula(Y ~ 1 + (1|G)), dat[:Dyestuff], REML=true)
 ```
 
 ### Simple, scalar random effects
@@ -59,30 +63,32 @@ It corresponds to a shift in the intercept for each level of the grouping factor
 The *sleepstudy* data are observations of reaction time, `Y`, on several subjects, `G`, after 0 to 9 days of sleep deprivation, `U`.
 A model with random intercepts and random slopes for each subject, allowing for within-subject correlation of the slope and intercept, is fit as
 ```{julia;term=true}
-fm2 = fit!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy]))
+fm2 = fit(MixedModel, @formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy])
 ```
 
 A model with uncorrelated random effects for the intercept and slope by subject is fit as
 ```{julia;term=true}
-# This model is not currently (v"2.0.0") available
-#fm3 = fit(LinearMixedModel, @formula(Y ~ 1 + U + (1|G) + (0+U|G)), dat[:sleepstudy])
+fm3 = fit!(zerocorr!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy])))
 ```
 
-Although technically there are two random-effects *terms* in the formula for *fm3* both have the same grouping factor
-and, internally, are amalgamated into a single vector-valued term.
+Note that the use of `zerocorr!` requires the model to be constructed, then altered to eliminate
+the correlation of the random effects, then fit with a call to the mutating function, `fit!`.
+```@docs
+zerocorr!
+```
 
 ### Models with multiple, scalar random-effects terms
 
 A model for the *Penicillin* data incorporates random effects for the plate, `G`, and for the sample, `H`.
 As every sample is used on every plate these two factors are *crossed*.
 ```{julia;term=true}
-fm4 = fit!(LinearMixedModel(@formula(Y ~ 1 + (1|G) + (1|H)), dat[:Penicillin]))
+fm4 = fit(MixedModel, @formula(Y ~ 1 + (1|G) + (1|H)), dat[:Penicillin])
 ```
 
 In contrast the sample, `G`, grouping factor is *nested* within the batch, `H`, grouping factor in the *Pastes* data.
 That is, each level of `G` occurs in conjunction with only one level of `H`.
 ```{julia;term=true}
-fm5 = fit!(LinearMixedModel(@formula(Y ~ 1 + (1|G) + (1|H)), dat[:Pastes]))
+fm5 = fit(MixedModel, @formula(Y ~ 1 + (1|G) + (1|H)), dat[:Pastes])
 ```
 
 In observational studies it is common to encounter *partially crossed* grouping factors.
@@ -102,7 +108,7 @@ the distribution family for the response, and possibly the link function, must b
 
 ```{julia;term=true}
 verbaggform = @formula(r2 ~ 1 + a + g + b + s + m + (1|id) + (1|item));
-gm1 = fit!(GeneralizedLinearMixedModel(verbaggform, dat[:VerbAgg], Bernoulli()))
+gm1 = fit(MixedModel, verbaggform, dat[:VerbAgg], Bernoulli())
 ```
 
 The canonical link, which is `GLM.LogitLink` for the `Bernoulli` distribution, is used if no explicit link is specified.
@@ -128,7 +134,7 @@ The optional argument `nAGQ=k` causes evaluation of the deviance function to use
 adaptive Gauss-Hermite quadrature rule.
 This method only applies to models with a single, simple, scalar random-effects term, such as
 ```{julia;term=true}
-contraform = @formula(use ~ 1 + a + l + urb + (1|d))
+contraform = @formula(use ~ 1 + a + abs2(a) + l + urb + (1|d))
 @time gm2 = fit!(GeneralizedLinearMixedModel(contraform, dat[:Contraception], Bernoulli()), nAGQ=9)
 @time deviance(fit!(GeneralizedLinearMixedModel(contraform, dat[:Contraception], Bernoulli()), nAGQ=9, fast=true))
 @time deviance(fit!(GeneralizedLinearMixedModel(contraform, dat[:Contraception], Bernoulli())))

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -91,7 +91,8 @@ export @formula,
        stderror,
        updateL!,
        varest,
-       vcov
+       vcov,
+       zerocorr!
 
 import Base: ==, *
 
@@ -99,10 +100,10 @@ abstract type MixedModel{T} <: StatsModels.RegressionModel end # model with fixe
 
 include("utilities.jl")
 include("arraytypes.jl")
-include("optsummary.jl")
 include("varcorr.jl")
 include("femat.jl")
 include("remat.jl")
+include("optsummary.jl")
 include("randomeffectsterm.jl")
 include("linearmixedmodel.jl")
 include("gausshermite.jl")

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -34,7 +34,7 @@ Base.getindex(A::ReMat, i::Integer, j::Integer) = getindex(A.adjA, j, i)
     nranef(A::ReMat)
 
 Return the number of random effects represented by `A`.  Zero unless `A` is an `ReMat`.
-""" 
+"""
 nranef(A::ReMat) = size(A.adjA, 1)
 
 LinearAlgebra.cond(A::ReMat) = cond(A.λ)
@@ -88,7 +88,7 @@ lowerbd(A::ReMat{T}) where {T} =
     isnested(A::ReMat, B::ReMat)
 
 Is the grouping factor for `A` nested in the grouping factor for `B`?
-    
+
 That is, does each value of `A` occur with just one value of B?
 """
 function isnested(A::ReMat, B::ReMat)
@@ -304,7 +304,7 @@ function reweight!(A::ReMat, sqrtwts::Vector)
     if length(sqrtwts) > 0
         if A.z === A.wtz
             A.wtz = similar(A.z)
-        end    
+        end
         rmul!(copyto!(A.wtz, A.z), Diagonal(sqrtwts))
     end
     A
@@ -346,7 +346,7 @@ end
 Overwrite L with `Λ'LΛ + I`
 """
 function scaleinflate! end
- 
+
 function scaleinflate!(Ljj::Diagonal{T}, Λj::ReMat{T,1}) where {T}
     Ljjd = Ljj.diag
     broadcast!((x, λsqr) -> x * λsqr + 1, Ljjd, Ljjd, abs2(first(Λj.λ)))
@@ -356,7 +356,7 @@ end
 function scaleinflate!(Ljj::Matrix{T}, Λj::ReMat{T,1}) where {T}
     lambsq = abs2(first(Λj.λ))
     @inbounds for i in diagind(Ljj)
-        Ljj[i] *= lambsq 
+        Ljj[i] *= lambsq
         Ljj[i] += one(T)
     end
     Ljj
@@ -417,3 +417,13 @@ function stddevcor(A::ReMat)
 end
 
 vsize(A::ReMat{T,S}) where {T,S} = S
+
+function zerocorr!(A::ReMat{T}) where {T}
+    λ = A.λ
+    A.inds = intersect(A.inds, diagind(λ))
+    fill!(λ.data, 0)
+    for i in A.inds
+        λ.data[i] = 1
+    end
+    A
+end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -196,29 +196,30 @@ end
 
     simulate!(fm)  # to test one of the unscaledre methods
 
-#    fmnc = LinearMixedModel(@formula(Y ~ 1 + U + (1|G) + (0+U|G)), dat[:sleepstudy])
-    @test_broken size(fmnc) == (180,2,36,1)
-    @test_broken fmnc.θ == ones(2)
-    @test_broken lowerbd(fmnc) == zeros(2)
+    fmnc = zerocorr!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)),
+        dat[:sleepstudy]))
+    @test size(fmnc) == (180,2,36,1)
+    @test fmnc.θ == ones(2)
+    @test lowerbd(fmnc) == zeros(2)
 
-#    fit!(fmnc)
+    fit!(fmnc)
 
-    @test_broken isapprox(deviance(fmnc), 1752.0032551398835, atol=0.001)
-    @test_broken isapprox(objective(fmnc), 1752.0032551398835, atol=0.001)
-    @test_broken coef(fmnc) ≈ [251.40510484848585, 10.467285959595715]
-    @test_broken fixef(fmnc) ≈ [10.467285959595715, 251.40510484848477]
-    @test_broken isapprox(stderror(fmnc), [6.707710260366577, 1.5193083237479683], atol=0.001)
-    @test_broken isapprox(fmnc.θ, [0.9458106880922268, 0.22692826607677266], atol=0.0001)
-    @test_broken std(fmnc)[1] ≈ [24.171449463289047, 5.799379721123582]
-    @test_broken std(fmnc)[2] ≈ [25.556130034081047]
-    @test_broken isapprox(logdet(fmnc), 74.46952585564611, atol=0.001)
+    @test deviance(fmnc) ≈ 1752.0032551398835 atol=0.001
+    @test objective(fmnc) ≈ 1752.0032551398835 atol=0.001
+    @test coef(fmnc) ≈ [251.40510484848585, 10.467285959595715]
+    @test fixef(fmnc) ≈ [251.40510484848477, 10.467285959595715]
+    @test stderror(fmnc) ≈ [6.707710260366577, 1.5193083237479683] atol=0.001
+    @test fmnc.θ ≈ [0.9458106880922268, 0.22692826607677266] atol=0.0001
+    @test first(std(fmnc)) ≈ [24.171449463289047, 5.799379721123582]
+    @test last(std(fmnc)) ≈ [25.556130034081047]
+    @test logdet(fmnc) ≈ 74.46952585564611 atol=0.001
 #    cor(fmnc)
 
 #    MixedModels.lrt(fm, fmnc)
 
     fmrs = fit!(LinearMixedModel(@formula(Y ~ 1 + U + (0 + U|G)), dat[:sleepstudy]))
-    @test isapprox(objective(fmrs), 1774.080315280528, rtol=0.00001)
-    @test isapprox(fmrs.θ, [0.24353985679033105], rtol=0.00001)
+    @test objective(fmrs) ≈ 1774.080315280528 rtol=0.00001
+    @test fmrs.θ ≈ [0.24353985679033105] rtol=0.00001
 end
 
 @testset "d3" begin


### PR DESCRIPTION
- add facilities to fit a model with vector-valued random effects in which estimation of the correlation parameters is suppressed.