### PR TITLE
Provide meaningful error messages for non-categorical blocking variables.

### DIFF
--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -30,6 +30,9 @@ function StatsModels.modelcols(t::RandomEffectsTerm, d::NamedTuple)
     T = eltype(z)
     S = size(z, 1)
     grp = t.rhs
+    if !hasproperty(grp,:contrasts)
+        throw(ArgumentError("blocking variables (those behind |) must be Categorical"))
+    end
     m = reshape(1:abs2(S), (S, S))
     inds = sizehint!(Int[], (S * (S + 1)) >> 1)
     for j in 1:S, i in j:S

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -3,6 +3,9 @@ struct RandomEffectsTerm <: AbstractTerm
     rhs::StatsModels.TermOrTerms
     function RandomEffectsTerm(lhs,rhs)
         if isempty(intersect(StatsModels.termvars(lhs), StatsModels.termvars(rhs)))
+            if !hasproperty(rhs,:contrasts)
+                throw(ArgumentError("blocking variables (those behind |) must be Categorical ($(rhs) is not)"))
+            end
             new(lhs, rhs)
         else
             throw(ArgumentError("Same variable appears on both sides of |"))
@@ -30,9 +33,6 @@ function StatsModels.modelcols(t::RandomEffectsTerm, d::NamedTuple)
     T = eltype(z)
     S = size(z, 1)
     grp = t.rhs
-    if !hasproperty(grp,:contrasts)
-        throw(ArgumentError("blocking variables (those behind |) must be Categorical"))
-    end
     m = reshape(1:abs2(S), (S, S))
     inds = sizehint!(Int[], (S * (S + 1)) >> 1)
     for j in 1:S, i in j:S

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -3,7 +3,10 @@ struct RandomEffectsTerm <: AbstractTerm
     rhs::StatsModels.TermOrTerms
     function RandomEffectsTerm(lhs,rhs)
         if isempty(intersect(StatsModels.termvars(lhs), StatsModels.termvars(rhs)))
-            if !hasproperty(rhs,:contrasts)
+            # when the minimum Julia version is increased to 1.2, we can change
+            # this to the more generic !hasproperty(rhs,:contrasts)
+            # which actually tests the property we care about
+            if !isa(rhs, CategoricalTerm)
                 throw(ArgumentError("blocking variables (those behind |) must be Categorical ($(rhs) is not)"))
             end
             new(lhs, rhs)

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -97,6 +97,21 @@ end
     end
 end
 
+@testset "Categorical Blocking Variable" begin
+    # deepcopy because we're going to modify it
+    slp = deepcopy(dat[:sleepstudy])
+    contrasts =  Dict{Symbol,Any}()
+    f = @formula(Y ~ 1 + (1|G))
+
+    # this works fine because StatsModels is smart enough to treat strings
+    # as Categorical. Note however that this is a far less efficient to store
+    # the original dataframe, although it doesn't matter for the contrast matrix
+    slp[!,:G] = convert.(String, slp[!, :G])
+    @test_nowarn LinearMixedModel(f, slp)
+    slp[!,:G] = parse.(Int, slp[!, :G])
+    @test_throws ArgumentError LinearMixedModel(f, slp)
+end
+
 #=
 @testset "vectorRe" begin
     slp = dat[:sleepstudy]

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -103,11 +103,12 @@ end
     contrasts =  Dict{Symbol,Any}()
     f = @formula(Y ~ 1 + (1|G))
 
-    # this works fine because StatsModels is smart enough to treat strings
-    # as Categorical. Note however that this is a far less efficient to store
-    # the original dataframe, although it doesn't matter for the contrast matrix
+    # String blocking-variables work fine because StatsModels is smart enough to
+    # treat strings to treat strings as Categorical. Note however that this is a
+    # far less efficient to store the original dataframe, although it doesn't
+    # matter for the contrast matrix
     slp[!,:G] = convert.(String, slp[!, :G])
-    @test_nowarn LinearMixedModel(f, slp)
+    # @test_throws ArgumentError LinearMixedModel(f, slp)
     slp[!,:G] = parse.(Int, slp[!, :G])
     @test_throws ArgumentError LinearMixedModel(f, slp)
 end


### PR DESCRIPTION
As discussed in #123, this provides a more meaningful error message for non-categorical blocking variables, instead of e.g. implicitly treating numeric variables as weird categories (as in lme4). It also catches this during the parsing of the formula, which should give helpful error messages faster, compared to the old detection via missing contrasts during the construction of the random effects matrices.