### PR TITLE
another specialized lmulΛ! method.

### DIFF
--- a/src/remat.jl
+++ b/src/remat.jl
@@ -126,6 +126,11 @@ function lmulΛ!(adjA::Adjoint{T,<:ReMat{T,S}}, B::BlockedSparse{T}) where {T,S}
     B
 end
 
+function lmulΛ!(adjA::Adjoint{T,ReMat{T,1}}, B::BlockedSparse{T,1,P}) where {T,P}
+    lmulΛ!(adjA, nonzeros(B.cscmat))
+    B
+end
+
 function lmulΛ!(adjA::Adjoint{T,<:ReMat{T,S}}, B::SparseMatrixCSC{T}) where {T,S}
     lmulΛ!(adjA, nonzeros(B))
     B


### PR DESCRIPTION
This addresses the type ambiguity issue found in the my reworked example in #123:

```
ERROR: MethodError: lmulΛ!(::LinearAlgebra.Adjoint{Float64,ReMat{Float64,1}}, ::BlockedSparse{Float64,1,2}) is ambiguous. Candidates:
  lmulΛ!(adjA::LinearAlgebra.Adjoint{T,#s32} where #s32<:ReMat{T,S}, B::BlockedSparse{T,S,P} where P where S) where {T, S} in MixedModels at /home/XXX/MixedModels.jl/src/remat.jl:125
  lmulΛ!(adjA::LinearAlgebra.Adjoint{T,ReMat{T,1}}, B::M) where {T, M<:AbstractArray{T,2}} in MixedModels at /home/XXX/MixedModels.jl/src/remat.jl:116
Possible fix, define
  lmulΛ!(::LinearAlgebra.Adjoint{T,ReMat{T,1}}, ::M<:(BlockedSparse{T,S,P} where P where S))
Stacktrace:
 [1] updateL!(::LinearMixedModel{Float64}) at /home/XXX/MixedModels.jl/src/linearmixedmodel.jl:625
 [2] #fit!#14(::Bool, ::Bool, ::typeof(fit!), ::LinearMixedModel{Float64}) at /home/XXX/MixedModels.jl/src/linearmixedmodel.jl:231
 [3] fit!(::LinearMixedModel{Float64}) at /home/XXX/MixedModels.jl/src/linearmixedmodel.jl:202
 [4] top-level scope at none:0
```
Fixes #123 .