### PR TITLE
Drop support for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: julia
 os:
   - linux
   - osx
-  - windows
 julia:
-  - 1.0
   - 1.2
   - 1.3
 codecov: true

--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ Showoff = "0.2, 0.3"
 StatsBase = "0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32"
 StatsFuns = "0.8"
 StatsModels = "0.6"
-julia = "1"
+julia = "1.2"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
Increase minimum Julia version to 1.2 -- it's faster, it has several features we want, and the tests for 1.0 keep failing for no good reason (e.g. timeouts and failure to download `Coverage.jl`).