### PR TITLE
add zerocorr within formula

### DIFF
--- a/docs/jmd/constructors.jmd
+++ b/docs/jmd/constructors.jmd
@@ -66,17 +66,6 @@ A model with random intercepts and random slopes for each subject, allowing for 
 fm2 = fit(MixedModel, @formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy])
 ```
 
-A model with uncorrelated random effects for the intercept and slope by subject is fit as
-```{julia;term=true}
-fm3 = fit!(zerocorr!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy])))
-```
-
-Note that the use of `zerocorr!` requires the model to be constructed, then altered to eliminate
-the correlation of the random effects, then fit with a call to the mutating function, `fit!`.
-```@docs
-zerocorr!
-```
-
 ### Models with multiple, scalar random-effects terms
 
 A model for the *Penicillin* data incorporates random effects for the plate, `G`, and for the sample, `H`.
@@ -96,6 +85,52 @@ For example, the *InstEval* data are course evaluations by students, `G`, of ins
 Additional covariates include the academic department, `I`, in which the course was given and `A`, whether or not it was a service course.
 ```{julia;term=true}
 fm6 = fit!(LinearMixedModel(@formula(Y ~ 1 + A * I + (1|G) + (1|H)), dat[:InstEval]))
+```
+
+### Simplifying the random effect correlation structure
+
+MixedEffects.jl estimates not only the *variance* of the effects for each random effect level, but also the *correlation* between the random effects for different predictors.
+So, for the model of the *sleepstudy* data above, one of the parameters that is estimated is the correlation between each subject's random intercept (i.e., their baseline reaction time) and slope (i.e., their particular change in reaction time over days of sleep deprivation).
+In some cases, you may wish to simplify the random effects structure by removing these correlation parameters.
+This often arises when there are many random effects you want to estimate (as is common in psychological experiments with many conditions and covariates), since the number of random effects parameters increases as the square of the number of predictors, making these models difficult to estimate from limited data.
+
+A model with uncorrelated random effects for the intercept and slope by subject is fit as
+```{julia;term=true}
+fm3 = fit!(zerocorr!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy])))
+```
+
+Note that the use of `zerocorr!` requires the model to be constructed, then altered to eliminate
+the correlation of the random effects, then fit with a call to the mutating function, `fit!`.
+```@docs
+zerocorr!
+```
+
+The special syntax `zerocorr` can be applied to individual random effects terms inside the `@formula`:
+```{julia;term=true}
+fit(MixedModel, @formula(Y ~ 1 + U + zerocorr(1+U|G)), dat[:sleepstudy])
+```
+
+Alternatively, correlations between parameters can be removed by including them as separate random effects terms:
+```{julia;term=true}
+fit(MixedModel, @formula(Y ~ 1 + U + (1|G) + (0+U|G)), dat[:sleepstudy])
+```
+Note that it's necessary to explicitly block the inclusion of an intercept term by adding `0`.
+
+Finally, for predictors that are categorical, MixedModels.jl will estimate correlations between each level.
+Notice the large number of correlation parameters if we treat `U` as a categorical variable by giving it contrasts:
+```{julia;term=true}
+fit(MixedModel, @formula(Y ~ 1 + U + (1+U|G)), dat[:sleepstudy], contrasts=Dict(:U=>DummyCoding()))
+```
+
+Separating the `1` and `U` random effects into separate terms removes the correlations between the intercept and the levels of `U`, but not between the levels themselves:
+```{julia;term=true}
+fit(MixedModel, @formula(Y ~ 1 + U + (1|G) + (0+U|G)), dat[:sleepstudy], contrasts=Dict(:U=>DummyCoding()))
+```
+
+But using `zerocorr` on the individual terms (or `zerocorr!` on the constructed model object as above) does remove the correlations between the levels:
+```{julia;term=true}
+fit(MixedModel, @formula(Y ~ 1 + U + zerocorr(1+U|G)), dat[:sleepstudy], contrasts=Dict(:U=>DummyCoding()))
+fit(MixedModel, @formula(Y ~ 1 + U + (1|G) + zerocorr(0+U|G)), dat[:sleepstudy], contrasts=Dict(:U=>DummyCoding()))
 ```
 
 ## Fitting generalized linear mixed models

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -97,6 +97,7 @@ export @formula,
        updateL!,
        varest,
        vcov,
+       zerocorr,
        zerocorr!
 
 import Base: ==, *

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -103,3 +103,27 @@ function StatsModels.apply_schema(t::FunctionTerm{typeof(fulldummy)},
                                   Mod::Type{<:MixedModel})
     fulldummy(apply_schema.(t.args_parsed, Ref(sch), Mod)...)
 end
+
+
+# specify zero correlation
+struct ZeroCorr <: AbstractTerm
+    term::RandomEffectsTerm
+end
+StatsModels.is_matrix_term(::Type{ZeroCorr}) = false
+
+"""
+    zerocorr(term::RandomEffectsTerm)
+
+Remove correlations between random effects in `term`.
+"""
+zerocorr(x) = ZeroCorr(x)
+
+function StatsModels.apply_schema(t::FunctionTerm{typeof(zerocorr)},
+                                  sch::StatsModels.FullRank,
+                                  Mod::Type{<:MixedModel})
+    ZeroCorr(apply_schema(t.args_parsed..., sch, Mod))
+end
+
+StatsModels.modelcols(t::ZeroCorr, d::NamedTuple) =
+    zerocorr!(modelcols(t.term, d))
+

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -235,6 +235,27 @@ end
     @test last(std(fmnc)) ≈ [25.556130034081047]
     @test logdet(fmnc) ≈ 74.46952585564611 atol=0.001
 
+    fmnc2 = LinearMixedModel(@formula(Y ~ 1 + U + zerocorr(1+U|G)),
+                             dat[:sleepstudy])
+    @test size(fmnc2) == (180,2,36,1)
+    @test fmnc2.θ == ones(2)
+    @test lowerbd(fmnc2) == zeros(2)
+
+    fit!(fmnc2)
+
+    @test deviance(fmnc2) ≈ 1752.0032551398835 atol=0.001
+    @test objective(fmnc2) ≈ 1752.0032551398835 atol=0.001
+    @test coef(fmnc2) ≈ [251.40510484848585, 10.467285959595715]
+    @test fixef(fmnc2) ≈ [251.40510484848477, 10.467285959595715]
+    @test stderror(fmnc2) ≈ [6.707710260366577, 1.5193083237479683] atol=0.001
+    @test fmnc2.θ ≈ [0.9458106880922268, 0.22692826607677266] atol=0.0001
+    @test first(std(fmnc2)) ≈ [24.171449463289047, 5.799379721123582]
+    @test last(std(fmnc2)) ≈ [25.556130034081047]
+    @test logdet(fmnc2) ≈ 74.46952585564611 atol=0.001
+    
+
+#    MixedModels.lrt(fm, fmnc)
+
     MixedModels.likelihoodratiotest(fm, fmnc)
 
     fmrs = LinearMixedModel(@formula(Y ~ 1 + U + (0 + U|G)), dat[:sleepstudy]);


### PR DESCRIPTION
This provides special syntax to be used within a formula to zero out
correlations on random effects terms:

``` julia
LinearMixedModel(@formula(Y ~ 1 + U + zerocorr(1+U|G)), dat)
```

which is equivalent to 

``` julia
zerocorr!(LinearMixedModel(@formula(Y ~ 1 + U + (1+U|G)), dat))
```