### PR TITLE
Restore printing of variance components

### DIFF
--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -24,6 +24,7 @@ using GLM: Link, canonicallink
 using StatsFuns: log2π
 
 import Base: *
+import GLM: dispersion, dispersion_parameter
 import NLopt: Opt
 import StatsBase: fit, fit!
 
@@ -61,6 +62,8 @@ export @formula,
        describeblocks,
        condVar,
        deviance,
+       dispersion,
+       dispersion_parameter,
        dof,
        dof_residual,
        fit,

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -105,6 +105,11 @@ function deviance!(m::GeneralizedLinearMixedModel, nAGQ=1)
     deviance(m, nAGQ)
 end
 
+GLM.dispersion(m::GeneralizedLinearMixedModel, sqr::Bool=false) =
+    dispersion(m.resp, dof_residual(m), sqr)
+
+GLM.dispersion_parameter(m::GeneralizedLinearMixedModel) = dispersion_parameter(m.resp.d)
+
 function StatsBase.dof(m::GeneralizedLinearMixedModel)
     length(m.β) + length(m.θ) + GLM.dispersion_parameter(m.resp.d)
 end

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -187,6 +187,10 @@ describeblocks(m::MixedModel) = describeblocks(stdout, m)
 
 StatsBase.deviance(m::MixedModel) = objective(m)
 
+GLM.dispersion(m::LinearMixedModel, sqr::Bool=false) = sqr ? varest(m) : sdest(m)
+
+GLM.dispersion_parameter(m::LinearMixedModel) = true
+
 StatsBase.dof(m::LinearMixedModel) = size(m)[2] + sum(nθ, m.reterms) + 1
 
 function StatsBase.dof_residual(m::LinearMixedModel)::Int

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -416,7 +416,8 @@ function σs(A::ReMat{T}, sc::T) where {T}
 end
 
 function σρs(A::ReMat{T,1}, sc::T) where {T}
-    NamedTuple{(:σ,)}((NamedTuple{(Symbol(first(A.cnames)),)}((sc*abs(first(A.λ.data)),)),))
+    NamedTuple{(:σ,:ρ)}((NamedTuple{(Symbol(first(A.cnames)),)}((sc*abs(first(A.λ.data)),)),
+        ()))
 end
 
 function ρ(i, λ::AbstractMatrix{T}, k, σs::NamedTuple, sc::T)::T where {T}

--- a/src/varcorr.jl
+++ b/src/varcorr.jl
@@ -13,50 +13,63 @@ variance-covariance matrices.
 
 The main purpose of defining this type is to isolate the logic in the show method.
 """
-struct VarCorr{T}
+struct VarCorr
     σρ::NamedTuple
-    s::T
+    s
 end
-VarCorr(m::MixedModel) = VarCorr(σρs(m), m.σ)
-
-function formats(vc::VarCorr)
-    σρ = vc.σρ
-    nmwd = max(10, maximum(textwidth.(string.(keys(σρ))))) + 1
-    cnmwd = max(6, maximum(textwidth.(string.(keys.(getproperty.(values(σρ), :σ))...,))))
-    σvec = [x for x in values.(getproperty.(values(σρ), :σ))...]
-    varwd = 1 + max(textwidth("Variance"), maximum(textwidth.(showoff(abs2.(σvec), :plain))))
-    stdwd = 1 + max(textwidth("Std.Dev."), maximum(textwidth.(showoff(σvec, :plain))))
-    nmwd, cnmwd, varwd, stdwd, maximum(length.(σvec))
-end
+VarCorr(m::MixedModel) =
+   VarCorr(σρs(m), dispersion_parameter(m) ? dispersion(m) : nothing)
 
 function Base.show(io::IO, vc::VarCorr)
-    nmwd, cnmwd, varwd, stdwd, nρ = formats(vc)
+    σρ = vc.σρ
+    nmvec = string.([keys(σρ)...])
+    cnmvec = string.(foldl(vcat, [keys(sig)...] for sig in getproperty.(values(σρ), :σ)))
+    σvec = vcat(collect.(values.(getproperty.(values(σρ), :σ)))...)
+    if !isnothing(vc.s)
+        push!(σvec, vc.s)
+        push!(nmvec, "Residual")
+    end
+    nmwd = maximum(textwidth.(nmvec)) + 1
+    cnmwd = maximum(textwidth.(cnmvec)) + 1
+    nρ = maximum(length.(getproperty.(values(σρ), :ρ)))
+    varvec = abs2.(σvec)
+    showσvec = showoff(σvec, :plain)
+    showvarvec = showoff(varvec, :plain)
+    varwd = maximum(textwidth.(showvarvec)) + 1
+    stdwd = maximum(textwidth.(showσvec)) + 1
     println(io, "Variance components:")
-    write(io, " "^(2+nmwd))
+    write(io, " "^(nmwd))
     write(io, cpad("Column", cnmwd))
     write(io, cpad("Variance", varwd))
     write(io, cpad("Std.Dev.", stdwd))
-    nρ > 1 && write(io,"  Corr.")
+    iszero(nρ) || write(io,"  Corr.")
     println(io)
-    for (n,v) in pairs(vc.σρ)
-        write(io, rpad(string(n), nmwd))
+    ind = 1
+    for (i,v) in enumerate(values(vc.σρ))
+        write(io, rpad(nmvec[i], nmwd))
         firstrow = true
-        for (cn, cv) in pairs(v.σ)
+        k = length(v.σ)   # number of columns in grp factor k
+        ρ = v.ρ
+        ρind = 0
+        for j in 1:k
             !firstrow && write(io, " "^nmwd)
-            write(io, rpad(string(cn), cnmwd))
-            write(io, lpad(first(showoff([abs2(cv)], :plain)), varwd))
-            write(io, lpad(first(showoff([cv], :plain)), stdwd))
+            write(io, rpad(cnmvec[ind], cnmwd))
+            write(io, lpad(showvarvec[ind], varwd))
+            write(io, lpad(showσvec[ind], stdwd))
+            for l in 1:(j - 1)
+                ρind += 1
+                @printf(io, "%6.2f", ρ[ρind])
+            end
             println(io)
             firstrow = false
+            ind += 1
         end
     end
-    write(io, rpad("Residual", nmwd))
-    write(io, " "^cnmwd)
-    write(io, lpad(first(showoff([abs2(vc.s)], :plain)), varwd))
-    write(io, lpad(first(showoff([vc.s], :plain)), stdwd))
+    if !isnothing(vc.s)
+        write(io, rpad(last(nmvec), nmwd))
+        write(io, " "^cnmwd)
+        write(io, lpad(showvarvec[ind], varwd))
+        write(io, lpad(showσvec[ind], stdwd))
+    end
+    println(io)
 end
-#= 
-            for k in 1:(j-1)
-                @printf(io, "%6.2f", cor[i][j, k])
-            end
-=#

--- a/src/varcorr.jl
+++ b/src/varcorr.jl
@@ -38,7 +38,7 @@ function Base.show(io::IO, vc::VarCorr)
     write(io, cpad("Std.Dev.", stdwd))
     nρ > 1 && write(io,"  Corr.")
     println(io)
-    for (n,v) in pairs(σρ)
+    for (n,v) in pairs(vc.σρ)
         write(io, rpad(string(n), nmwd))
         firstrow = true
         for (cn, cv) in pairs(v.σ)
@@ -46,12 +46,16 @@ function Base.show(io::IO, vc::VarCorr)
             write(io, rpad(string(cn), cnmwd))
             write(io, lpad(first(showoff([abs2(cv)], :plain)), varwd))
             write(io, lpad(first(showoff([cv], :plain)), stdwd))
+            println(io)
             firstrow = false
         end
-        println(io)
     end
+    write(io, rpad("Residual", nmwd))
+    write(io, " "^cnmwd)
+    write(io, lpad(first(showoff([abs2(vc.s)], :plain)), varwd))
+    write(io, lpad(first(showoff([vc.s], :plain)), stdwd))
 end
-#=        # FIXME: Do this one term at a time
+#= 
             for k in 1:(j-1)
                 @printf(io, "%6.2f", cor[i][j, k])
             end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -52,7 +52,7 @@ const LMM = LinearMixedModel
     @test fm1.b == ranef(fm1)
     @test fm1.u == ranef(fm1, uscale=true)
     @test fm1.stderror == stderror(fm1)
-    @test isone(length(fm1.pvalue))
+    @test isone(length(fm1.pvalues))
     @test fm1.objective == objective(fm1)
     @test fm1.σ ≈ 49.510099986291145 atol=1.e-5
     @test fm1.X == ones(30,1)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -19,6 +19,7 @@ const LMM = LinearMixedModel
     @test fm1.θ == ones(1)
     fm1.θ = ones(1)
     @test fm1.θ == ones(1)
+#    @test_warn "Model has not been fit" show(fm1)
 
     @test objective(updateL!(setθ!(fm1, [0.713]))) ≈ 327.34216280955366
     MixedModels.describeblocks(IOBuffer(), fm1)
@@ -38,7 +39,21 @@ const LMM = LinearMixedModel
     @test nobs(fm1) == 30
     @test MixedModels.fixef!(zeros(1),fm1) ≈ [1527.5]
     @test coef(fm1) ≈ [1527.5]
+    fm1β = fm1.βs
+    @test fm1β isa NamedTuple
+    @test isone(length(fm1β))
+    @test first(values(fm1β)) ≈ 1527.5
+    fm1σρ = fm1.σρs
+    @test fm1σρ isa NamedTuple
+    @test isone(length(fm1σρ))
+    @test isone(length(getproperty(first(fm1σρ), :σ)))
+    @test isempty(getproperty(first(fm1σρ), :ρ))
     @test fm1.σ == sdest(fm1)
+    @test fm1.b == ranef(fm1)
+    @test fm1.u == ranef(fm1, uscale=true)
+    @test fm1.stderror == stderror(fm1)
+    @test isone(length(fm1.pvalue))
+    @test fm1.objective == objective(fm1)
     @test fm1.σ ≈ 49.510099986291145 atol=1.e-5
     @test fm1.X == ones(30,1)
     @test fm1.y == dat[:Dyestuff][!, :Y]
@@ -67,6 +82,7 @@ const LMM = LinearMixedModel
 
     fit!(fm1, REML=true)
     @test objective(fm1) ≈ 319.65427684225216 atol=0.0001
+    @test_throws ArgumentError loglikelihood(fm1)
     @test dof_residual(fm1) ≥ 0
     print(IOBuffer(), fm1)
 end


### PR DESCRIPTION
- Switch to `NamedTuple` representation of standard deviations and correlations using the `m.σρs` extractor.
- `VarCorr` simply contains this `NamedTuple` and the dispersion parameter.
- Clean up the show method for `VarCorr`.
- Add tests for more coverage.