### PR TITLE
Fix error from returning SVector for theta

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -323,9 +323,7 @@ end
 
 function Base.getproperty(m::LinearMixedModel, s::Symbol)
     if s == :θ || s == :theta
-        v = getθ(m)
-        
-        SVector{length(v)}(v)
+        getθ(m)
     elseif s == :β || s == :beta
         coef(m)
     elseif s == :βs || s == :betas

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -324,6 +324,7 @@ end
 function Base.getproperty(m::LinearMixedModel, s::Symbol)
     if s == :θ || s == :theta
         v = getθ(m)
+        
         SVector{length(v)}(v)
     elseif s == :β || s == :beta
         coef(m)


### PR DESCRIPTION
`parametricbootstrap` tries to write to elements of theta, but the theta that is
returned by getproperty is an SVector, so this errors

@palday I'll push a fix once the error is confirmed