### PR TITLE
update BlockArrays support.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
-BlockArrays = "0.3, 0.4, 0.5, 0.6, 0.7"
+BlockArrays = "0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
 Distributions = "0.15, 0.16, 0.17, 0.18, 0.19, 0.20, 0.21"
 GLM = "1"
 NLopt = "0.5"

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -77,8 +77,8 @@ function LinearMixedModel(f::FormulaTerm, tbl::Tables.ColumnTable;
     terms = vcat(reterms, feterms)
     k = length(terms)
     sz = append!(size.(reterms, 2), rank.(feterms))
-    A = BlockArrays._BlockArray(AbstractMatrix{T}, sz, sz)
-    L = BlockArrays._BlockArray(AbstractMatrix{T}, sz, sz)
+    A = BlockArray(undef_blocks, AbstractMatrix{T}, sz, sz)
+    L = BlockArray(undef_blocks, AbstractMatrix{T}, sz, sz)
     for j in 1:k
         for i in j:k
             Lij = L[Block(i,j)] = densify(terms[i]'terms[j])

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra, MixedModels, Random, SparseArrays, StatsModels, Test
+using DataFrames, LinearAlgebra, MixedModels, Random, SparseArrays, StatsModels, Test
 using MixedModels: mulαβ!
 
 @testset "mulαβ!" begin


### PR DESCRIPTION
Uses the suggestion from #216 to use `AbstractMatrix` as block type that doesn't lose subtype information to address `BlockArrays > 0.7.0` compatibility.
```julia
julia> B = Matrix{AbstractMatrix{Float64}}(undef,2,1)

julia> B[1,1] = fill(1.0,2,2)

julia> B[2,1] = sparse(I,2,2)

julia> A = mortar(B)
2×1-blocked 4×2 BlockArray{Float64,2,Array{AbstractArray{Float64,2},2},BlockArrays.BlockSizes{2,Tuple{Array{Int64,1},Array{Int64,1}}}}:
 1.0  1.0
 1.0  1.0
 ────────
 1.0  0.0
 0.0  1.0

julia> A[Block(1,1)]
2×2 Array{Float64,2}:
 1.0  1.0
 1.0  1.0

julia> A[Block(2,1)]
2×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:
  [1, 1]  =  1.0
  [2, 2]  =  1.0
```

_Originally posted by @dlfivefifty in https://github.com/dmbates/MixedModels.jl/pull/216#issuecomment-542524324_

 Resolves #215. Depends on #216 (and will be rebased once that lands).

Note that I also removed support for `BlockArrays 0.3, 0.4` because a preliminary glance at the release notes suggests those versions don't support Julia 1.2. I've tested locally on `BlockArrays 0.5, 0.7, 0.8, 0.9, 0.10`, but I haven't done any performance comparisons.